### PR TITLE
fix: support duplicate tutorial shot image references

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ should migrate to the static UI WebP output policy:
 - crop
 - box / arrow / short label annotations
 - generated page-local WebP output image for static UI screenshots, with animated WebP raw uploads preserved as animated WebP
+- independent editing for every `Action` / `Verify` reference, even when several tags initially share one image path; saving one shared reference automatically branches it to a unique generated image
 
 See [Tutorial Shot Editor](./docs/tutorial-shot-editor.md) for the architecture,
 canonical files, and authoring rules.

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ should migrate to the static UI WebP output policy:
 - crop
 - box / arrow / short label annotations
 - generated page-local WebP output image for static UI screenshots, with animated WebP raw uploads preserved as animated WebP
-- independent editing for every `Action` / `Verify` reference, even when several tags initially share one image path; saving one shared reference automatically branches it to a unique generated image
+- independent editing for every `Action` / `Verify` reference; saving automatically branches one reference when its generated WebP, manifest, or raw image would collide with another reference
 
 See [Tutorial Shot Editor](./docs/tutorial-shot-editor.md) for the architecture,
 canonical files, and authoring rules.

--- a/docs/tutorial-shot-editor.md
+++ b/docs/tutorial-shot-editor.md
@@ -54,14 +54,17 @@ project-contract:
     - /dev/tutorial-shots
   ai_surface:
     - shot manifest JSON
-    - MDX Action image references
+    - MDX Action/Verify image references
   sync:
     direction: canonical_to_generated
     trigger:
       - Save Shot in the editor
       - future generate:tutorial-images CLI
   conflict_policy:
-    - MDX stays authoritative for which Action images exist
+    - MDX stays authoritative for which Action/Verify image references exist
+    - each Action/Verify reference is selected by its scanned source range and page revision, not by its image path
+    - a stale page revision rejects the save before MDX or image artifacts are changed
+    - saving one of several references to the same image branches only that reference to a collision-free `--<hex>.webp` path
     - shot manifest stays authoritative for crop/annotations
     - generated img/*.webp is overwritten from manifest on save for static UI screenshots and tested animated WebP uploads
     - legacy PNG Action/Verify references are rewritten to the policy WebP path on save
@@ -123,6 +126,8 @@ Rule of thumb:
 MVP goals:
 
 - detect existing `Action img="./img/...png"` / `Verify img="./img/...png"` references and migrate static UI output to WebP on save
+- list repeated uses of the same image as independent editable references, including cross-page uses
+- branch only the saved reference to an automatically suffixed image when its current image is shared
 - bootstrap a raw source from the current output image when needed
 - import source images through the upload button, drag-and-drop, or `Ctrl + V`
 - save crop + annotations beside the page in `shots/`

--- a/docs/tutorial-shot-editor.md
+++ b/docs/tutorial-shot-editor.md
@@ -64,7 +64,10 @@ project-contract:
     - MDX stays authoritative for which Action/Verify image references exist
     - each Action/Verify reference is selected by its scanned source range and page revision, not by its image path
     - a stale page revision rejects the save before MDX or image artifacts are changed
-    - saving one of several references to the same image branches only that reference to a collision-free `--<hex>.webp` path
+    - saving branches only the selected reference when its generated WebP, manifest, or raw image path collides with another reference
+    - generated artifact comparisons resolve inside the content source root and are case-insensitive on Windows
+    - a failed multi-file install rolls back in reverse order and retains any backup that cannot be restored
+    - cleanup-only failures after every authoritative file is installed return a successful save with a warning
     - shot manifest stays authoritative for crop/annotations
     - generated img/*.webp is overwritten from manifest on save for static UI screenshots and tested animated WebP uploads
     - legacy PNG Action/Verify references are rewritten to the policy WebP path on save
@@ -127,7 +130,7 @@ MVP goals:
 
 - detect existing `Action img="./img/...png"` / `Verify img="./img/...png"` references and migrate static UI output to WebP on save
 - list repeated uses of the same image as independent editable references, including cross-page uses
-- branch only the saved reference to an automatically suffixed image when its current image is shared
+- branch only the saved reference to automatically suffixed WebP, manifest, and raw paths when any generated artifact would be shared
 - bootstrap a raw source from the current output image when needed
 - import source images through the upload button, drag-and-drop, or `Ctrl + V`
 - save crop + annotations beside the page in `shots/`

--- a/scripts/run-tutorial-shot-editor-flow-tests.mjs
+++ b/scripts/run-tutorial-shot-editor-flow-tests.mjs
@@ -6,6 +6,7 @@ const testFile = "tests/tutorial-shot-editor-flow.test.mjs";
 
 const testNames = [
   "tutorial shot editor saves one boxed focal point with an optional arrow",
+  "tutorial shot editor keeps shared image references independently selectable and saves only one",
   "tutorial shot editor can edit an Action image whose filename contains spaces",
   "tutorial shot editor accepts an image pasted from the clipboard",
   "tutorial shot editor imports a dropped source image",
@@ -28,7 +29,13 @@ const runOne = (testName) =>
     cleanupWorktreeDevProcesses();
     const child = spawn(
       process.execPath,
-      ["--test", "--test-concurrency=1", "--test-name-pattern", `^${escapeRegExp(testName)}$`, testFile],
+      [
+        "--test",
+        "--test-concurrency=1",
+        "--test-name-pattern",
+        `^${escapeRegExp(testName)}$`,
+        testFile,
+      ],
       {
         env: process.env,
         stdio: "inherit",

--- a/src/app/api/dev/tutorial-shots/save/route.ts
+++ b/src/app/api/dev/tutorial-shots/save/route.ts
@@ -3,6 +3,7 @@ import { bumpRevision } from "../../../../../lib/dev-reload-bus";
 import {
   getTutorialShotAuthoringContext,
   saveTutorialShot,
+  TutorialShotConflictError,
 } from "../../../../../lib/tutorial-shots-server.mjs";
 
 export const dynamic = "force-dynamic";
@@ -68,6 +69,7 @@ export async function POST(request: Request) {
 
     const result = await saveTutorialShot({
       sourceRoot: context.sourceRoot,
+      sourceRef: body.sourceRef,
       manifestInput: body.manifest,
       rawImageDataUrl: typeof body.rawImageDataUrl === "string" ? body.rawImageDataUrl : null,
       rawImageFileName: typeof body.rawImageFileName === "string" ? body.rawImageFileName : null,
@@ -87,6 +89,7 @@ export async function POST(request: Request) {
       {
         ok: true,
         manifest: result.manifest,
+        sourceRef: result.sourceRef,
         warnings: result.warnings,
       },
       {
@@ -96,13 +99,14 @@ export async function POST(request: Request) {
       },
     );
   } catch (error) {
+    const status = error instanceof TutorialShotConflictError ? 409 : 500;
     return NextResponse.json(
       {
         error:
           error instanceof Error ? error.message : "チュートリアル画像を保存できませんでした。",
       },
       {
-        status: 500,
+        status,
         headers: {
           "cache-control": "no-store, max-age=0",
         },

--- a/src/app/dev/tutorial-shots/tutorial-shot-editor.tsx
+++ b/src/app/dev/tutorial-shots/tutorial-shot-editor.tsx
@@ -28,6 +28,7 @@ import type {
   TutorialShotManifest,
   TutorialShotItem,
   TutorialShotResponse,
+  TutorialShotSourceRef,
 } from "../../../lib/tutorial-shots-types";
 import styles from "./tutorial-shot-editor.module.css";
 
@@ -79,6 +80,18 @@ const getReadableImageName = (file: File, fallbackFileName: string) => {
 
 const getUnsupportedSourceImageMessage = (file: File) =>
   `${getReadableImageName(file, "選択したファイル")} は読み込めません。読み込める画像は ${TUTORIAL_SHOT_SOURCE_IMAGE_FORMAT_LABEL} です。`;
+
+const getTutorialShotSourceRef = (shot: TutorialShotItem): TutorialShotSourceRef => ({
+  pagePath: shot.pagePath,
+  tagName: shot.tagName,
+  tagStart: shot.tagStart,
+  tagEnd: shot.tagEnd,
+  imgValueStart: shot.imgValueStart,
+  imgValueEnd: shot.imgValueEnd,
+  expectedImg: shot.expectedImg,
+  pageRevision: shot.pageRevision,
+  referenceKey: shot.referenceKey,
+});
 
 const hasFileTransfer = (dataTransfer: DataTransfer | null) =>
   Boolean(dataTransfer?.files.length) ||
@@ -344,7 +357,7 @@ export default function TutorialShotEditor() {
 
   const shots = useMemo(() => (response && response.enabled ? response.shots : []), [response]);
   const selectedShot = useMemo(
-    () => shots.find((shot) => shot.outputImagePath === selectedKey) ?? null,
+    () => shots.find((shot) => shot.referenceKey === selectedKey) ?? null,
     [selectedKey, shots],
   );
   const warnings = useMemo(
@@ -422,9 +435,9 @@ export default function TutorialShotEditor() {
       setResponse(data);
       if (data.enabled && data.shots.length > 0) {
         setSelectedKey((current) =>
-          data.shots.some((shot) => shot.outputImagePath === current)
+          data.shots.some((shot) => shot.referenceKey === current)
             ? current
-            : data.shots[0].outputImagePath,
+            : data.shots[0].referenceKey,
         );
         return;
       }
@@ -471,7 +484,7 @@ export default function TutorialShotEditor() {
 
     const storedCropState = getStoredTutorialShotCropState({
       currentCropStates: cropStatesByShotRef.current,
-      shotKey: selectedShot.outputImagePath,
+      shotKey: selectedShot.referenceKey,
     }) as TutorialShotEditorStoredCropState | null;
     // When loading a Verify shot, automatically fix any legacy role="action" boxes
     // to role="verify". This handles .shot.json files that were created before the
@@ -510,12 +523,12 @@ export default function TutorialShotEditor() {
     setSourceImageElement(null);
     setCrop(storedCropState?.crop ?? undefined);
     setCompletedCrop(storedCropState?.completedCrop ?? null);
-    setCropOwnerKey(selectedShot.outputImagePath);
+    setCropOwnerKey(selectedShot.referenceKey);
     setCroppedPreviewSrc(null);
   }, [selectedShot, sourceImageRevision, sourceOverride]);
 
   useEffect(() => {
-    const activeShotKey = selectedShot?.outputImagePath ?? null;
+    const activeShotKey = selectedShot?.referenceKey ?? null;
     if (!activeShotKey || cropOwnerKey !== activeShotKey || (!crop && !completedCrop)) {
       return;
     }
@@ -662,7 +675,7 @@ export default function TutorialShotEditor() {
   };
 
   const save = async () => {
-    if (!draftManifest) {
+    if (!draftManifest || !selectedShot) {
       return;
     }
     if (hasAnnotationSurface && annotationErrors.length > 0) {
@@ -672,57 +685,79 @@ export default function TutorialShotEditor() {
 
     setIsSaving(true);
     setStatusText("保存しています…");
+    try {
+      const manifestToSave = normalizeTutorialShotManifest({
+        ...draftManifest,
+        crop: completedCrop
+          ? {
+              x: completedCrop.x,
+              y: completedCrop.y,
+              width: completedCrop.width,
+              height: completedCrop.height,
+            }
+          : null,
+      }) as TutorialShotManifest;
 
-    const manifestToSave = normalizeTutorialShotManifest({
-      ...draftManifest,
-      crop: completedCrop
-        ? {
-            x: completedCrop.x,
-            y: completedCrop.y,
-            width: completedCrop.width,
-            height: completedCrop.height,
-          }
-        : null,
-    }) as TutorialShotManifest;
+      const saveResponse = await fetch("/api/dev/tutorial-shots/save", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          manifest: manifestToSave,
+          sourceRef: getTutorialShotSourceRef(selectedShot),
+          rawImageDataUrl: pendingRawDataUrl,
+          rawImageFileName: pendingRawFileName,
+          bootstrapFromOutput: bootstrapFromOutput && !pendingRawDataUrl,
+          bootstrapImagePath:
+            bootstrapFromOutput && !pendingRawDataUrl ? selectedShot.bootstrapImagePath : null,
+          source: sourceOverride,
+        }),
+      });
 
-    const saveResponse = await fetch("/api/dev/tutorial-shots/save", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        manifest: manifestToSave,
-        rawImageDataUrl: pendingRawDataUrl,
-        rawImageFileName: pendingRawFileName,
-        bootstrapFromOutput: bootstrapFromOutput && !pendingRawDataUrl,
-        bootstrapImagePath:
-          bootstrapFromOutput && !pendingRawDataUrl ? selectedShot?.bootstrapImagePath : null,
-        source: sourceOverride,
-      }),
-    });
+      const saveData = await saveResponse.json();
+      if (!saveResponse.ok) {
+        setStatusText(saveData.error ?? "保存できませんでした。");
+        return;
+      }
 
-    const saveData = await saveResponse.json();
-    if (!saveResponse.ok) {
-      setStatusText(saveData.error ?? "保存できませんでした。");
+      // The saved MDX may now have a different revision and source range.
+      // Drop the stale key before rescanning so it can never be submitted twice.
+      setSelectedKey("");
+      const listResponse = await fetch(buildTutorialShotsListUrl(sourceOverride ?? ""), {
+        cache: "no-store",
+      });
+      const listData = (await listResponse.json()) as TutorialShotResponse;
+      if (!listResponse.ok) {
+        throw new Error(
+          listData.enabled === false ? listData.reason : "保存後の画像一覧を読み込めませんでした。",
+        );
+      }
+      setResponse(listData);
+      const savedReferenceKey =
+        typeof saveData.sourceRef?.referenceKey === "string" ? saveData.sourceRef.referenceKey : "";
+      setSelectedKey(
+        listData.enabled && listData.shots.some((shot) => shot.referenceKey === savedReferenceKey)
+          ? savedReferenceKey
+          : listData.enabled
+            ? (listData.shots[0]?.referenceKey ?? "")
+            : "",
+      );
+      cropStatesByShotRef.current = {};
+      setCropStatesByShot({});
+      setStatusText(
+        saveData.warnings?.length
+          ? `保存しました（確認したいこと ${saveData.warnings.length} 件）`
+          : "保存しました",
+      );
+      setPendingRawDataUrl(null);
+      setPendingRawFileName(null);
+      setSourceImageRevision((value) => value + 1);
+    } catch (error) {
+      setStatusText(error instanceof Error ? error.message : "保存できませんでした。");
+    } finally {
       setIsSaving(false);
-      return;
     }
-
-    setStatusText(
-      saveData.warnings?.length
-        ? `保存しました（確認したいこと ${saveData.warnings.length} 件）`
-        : "保存しました",
-    );
-    setPendingRawDataUrl(null);
-    setPendingRawFileName(null);
-    setSourceImageRevision((value) => value + 1);
-    setIsSaving(false);
-
-    const listResponse = await fetch(buildTutorialShotsListUrl(sourceOverride ?? ""), {
-      cache: "no-store",
-    });
-    const listData = (await listResponse.json()) as TutorialShotResponse;
-    setResponse(listData);
   };
 
   const applySourceOverride = (nextSource: string) => {
@@ -903,7 +938,7 @@ export default function TutorialShotEditor() {
     };
     setCrop(fullCrop);
     setCompletedCrop(fullCrop);
-    setCropOwnerKey(selectedShot?.outputImagePath ?? null);
+    setCropOwnerKey(selectedShot?.referenceKey ?? null);
   };
 
   if (!response) {
@@ -1056,26 +1091,29 @@ export default function TutorialShotEditor() {
           </div>
           <ul className={styles.shotList}>
             {shots.map((shot) => {
-              const isActive = shot.outputImagePath === selectedKey;
+              const isActive = shot.referenceKey === selectedKey;
               const flags = getShotFlags(shot);
               return (
-                <li key={shot.outputImagePath}>
+                <li key={shot.referenceKey}>
                   <button
                     aria-current={isActive ? "true" : undefined}
                     className={`${styles.shotRow} ${isActive ? styles.shotRowActive : ""}`}
                     onClick={() => {
                       setStatusText("");
-                      setSelectedKey(shot.outputImagePath);
+                      setSelectedKey(shot.referenceKey);
                     }}
                     type="button"
                   >
                     <div className={styles.shotRowTitle}>{shot.id}</div>
+                    <div className={styles.shotRowMeta}>
+                      {shot.tagName} ・ {shot.line} 行目
+                    </div>
                     <div className={styles.shotRowMeta}>{shot.pagePath}</div>
                     <div className={styles.shotRowFlags}>
                       {flags.map((flag) => (
                         <span
                           className={`${styles.flag} ${flag.className}`}
-                          key={`${shot.outputImagePath}:${flag.label}`}
+                          key={`${shot.referenceKey}:${flag.label}`}
                           title={flag.title}
                         >
                           {flag.label}
@@ -1249,7 +1287,7 @@ export default function TutorialShotEditor() {
                                   cw > 0 ? sourceImageElement.naturalWidth / cw : 1;
                               }
                               setCrop(toNaturalCrop(nextCrop, cropDisplayScaleRef.current));
-                              setCropOwnerKey(selectedShot.outputImagePath);
+                              setCropOwnerKey(selectedShot.referenceKey);
                             }}
                             onComplete={(nextCrop) => {
                               if (sourceImageElement) {
@@ -1260,7 +1298,7 @@ export default function TutorialShotEditor() {
                               setCompletedCrop(
                                 toNaturalCrop(nextCrop, cropDisplayScaleRef.current),
                               );
-                              setCropOwnerKey(selectedShot.outputImagePath);
+                              setCropOwnerKey(selectedShot.referenceKey);
                             }}
                           >
                             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -1273,13 +1311,13 @@ export default function TutorialShotEditor() {
                                 cropDisplayScaleRef.current = cw > 0 ? image.naturalWidth / cw : 1;
                                 const nextCropState = getTutorialShotCropStateForImage({
                                   currentCropStates: cropStatesByShotRef.current,
-                                  shotKey: selectedShot.outputImagePath,
+                                  shotKey: selectedShot.referenceKey,
                                   manifestCrop: draftManifest.crop,
                                   imageWidth: image.naturalWidth,
                                   imageHeight: image.naturalHeight,
                                 }) as TutorialShotEditorStoredCropState;
                                 setSourceImageElement(image);
-                                setCropOwnerKey(selectedShot.outputImagePath);
+                                setCropOwnerKey(selectedShot.referenceKey);
                                 setCrop(
                                   nextCropState.crop ?? createInitialCrop(image, draftManifest),
                                 );

--- a/src/lib/tutorial-shots-server.mjs
+++ b/src/lib/tutorial-shots-server.mjs
@@ -20,6 +20,7 @@ import {
   isExpectedTutorialShotRawImagePath,
   isTutorialShotManifestPath,
   isTutorialShotOutputImagePath,
+  isTutorialShotRawImagePath,
   isTutorialShotReadableImagePath,
   normalizeDecodedPosixPath,
   normalizePosixPath,
@@ -27,6 +28,7 @@ import {
   replaceTutorialShotPathExtension,
   renderTutorialShotOverlaySvg,
   isTutorialShotSourceImageMimeType,
+  TUTORIAL_SHOT_SOURCE_IMAGE_FORMATS,
 } from "./tutorial-shots-shared.mjs";
 
 const PAGE_PATH_PATTERN = /^content\/.+\/index\.mdx?$/iu;
@@ -43,6 +45,9 @@ const SHARP_RAW_UPLOAD_FORMAT_EXTENSIONS = new Map([
   ["svg", new Set([".svg"])],
   ["bmp", new Set([".bmp", ".dib"])],
 ]);
+const TUTORIAL_SHOT_RAW_IMAGE_EXTENSIONS = [
+  ...new Set(TUTORIAL_SHOT_SOURCE_IMAGE_FORMATS.flatMap((format) => format.extensions)),
+];
 
 const isLocalPathLike = (value) =>
   value.startsWith(".") ||
@@ -176,8 +181,84 @@ const resolveSourcePath = ({ sourceRoot, contentRelativePath, validator }) => {
   });
 };
 
-const ensureParentDir = async (filePath) => {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
+const isTutorialShotArtifactPath = (contentPath) =>
+  isTutorialShotOutputImagePath(contentPath) ||
+  isTutorialShotManifestPath(contentPath) ||
+  isTutorialShotRawImagePath(contentPath);
+
+export const getTutorialShotArtifactPaths = (ref) => {
+  const requestedOutputImagePath = ref.referencedImagePath ?? ref.outputImagePath;
+  const derived = deriveTutorialShotPaths({
+    pagePath: ref.pagePath,
+    outputImagePath: requestedOutputImagePath,
+    rawImageExtension: getTutorialShotFileExtension(ref.rawImagePath ?? requestedOutputImagePath),
+  });
+  const rawImagePath = isExpectedTutorialShotRawImagePath({
+    pagePath: ref.pagePath,
+    outputImagePath: derived.outputImagePath,
+    rawImagePath: ref.rawImagePath,
+  })
+    ? normalizeDecodedPosixPath(ref.rawImagePath)
+    : derived.rawImagePath;
+
+  return {
+    outputImagePath: derived.outputImagePath,
+    manifestPath: derived.manifestPath,
+    rawImagePath,
+  };
+};
+
+export const getTutorialShotArtifactIdentity = ({
+  sourceRoot,
+  contentRelativePath,
+  platform = process.platform,
+}) => {
+  const absolutePath = resolveSourcePath({
+    sourceRoot,
+    contentRelativePath,
+    validator: isTutorialShotArtifactPath,
+  });
+  return platform === "win32" ? absolutePath.toLowerCase() : absolutePath;
+};
+
+const getFileSystemPathIdentity = ({ sourceRoot, absolutePath, platform = process.platform }) => {
+  const insideRootPath = ensureInsideRoot({ rootDir: sourceRoot, resolvedPath: absolutePath });
+  return platform === "win32" ? insideRootPath.toLowerCase() : insideRootPath;
+};
+
+const tutorialShotArtifactPathsShareArtifacts = ({
+  sourceRoot,
+  leftPaths,
+  rightPaths,
+  platform = process.platform,
+}) => {
+  const leftIdentities = new Set(
+    Object.values(leftPaths).map((contentRelativePath) =>
+      getTutorialShotArtifactIdentity({ sourceRoot, contentRelativePath, platform }),
+    ),
+  );
+  return Object.values(rightPaths).some((contentRelativePath) =>
+    leftIdentities.has(
+      getTutorialShotArtifactIdentity({ sourceRoot, contentRelativePath, platform }),
+    ),
+  );
+};
+
+export const tutorialShotRefsShareArtifacts = ({
+  sourceRoot,
+  left,
+  right,
+  platform = process.platform,
+}) =>
+  tutorialShotArtifactPathsShareArtifacts({
+    sourceRoot,
+    leftPaths: getTutorialShotArtifactPaths(left),
+    rightPaths: getTutorialShotArtifactPaths(right),
+    platform,
+  });
+
+const ensureParentDir = async (filePath, fileOps = fs) => {
+  await fileOps.mkdir(path.dirname(filePath), { recursive: true });
 };
 
 const hydrateManifest = (manifestInput) => {
@@ -539,8 +620,36 @@ const scanTutorialShotSourceState = async ({ sourceRoot }) => {
     return left.tagStart - right.tagStart;
   });
 
+  const artifactPathsByReferenceKey = new Map();
+  for (const ref of refs) {
+    const defaultArtifactPaths = getTutorialShotArtifactPaths(ref);
+    const manifestAbsolutePath = resolveSourcePath({
+      sourceRoot,
+      contentRelativePath: defaultArtifactPaths.manifestPath,
+      validator: isTutorialShotManifestPath,
+    });
+    const rawManifest = await readJsonIfExists(manifestAbsolutePath);
+    const manifest = hydrateManifest(
+      rawManifest
+        ? {
+            ...rawManifest,
+            pagePath: ref.pagePath,
+            outputImagePath: defaultArtifactPaths.outputImagePath,
+          }
+        : createDefaultTutorialShotManifest({
+            pagePath: ref.pagePath,
+            outputImagePath: defaultArtifactPaths.outputImagePath,
+          }),
+    );
+    artifactPathsByReferenceKey.set(
+      ref.referenceKey,
+      getTutorialShotArtifactPaths({ ...ref, rawImagePath: manifest.rawImagePath }),
+    );
+  }
+
   return {
     allFiles,
+    artifactPathsByReferenceKey,
     pages,
     refs,
   };
@@ -722,9 +831,9 @@ const assertTutorialShotSourceStateUnchanged = async ({ sourceRoot, sourceState 
   }
 };
 
-const resolveExistingFile = async (filePath) => {
+const resolveExistingFile = async (filePath, fileOps = fs) => {
   try {
-    const stats = await fs.stat(filePath);
+    const stats = await fileOps.stat(filePath);
     return stats.isFile();
   } catch (error) {
     if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
@@ -738,9 +847,18 @@ const allocateBranchedTutorialShotPaths = ({ sourceRoot, sourceState, manifest }
   const outputExtension = path.posix.extname(manifest.outputImagePath);
   const outputStem = manifest.outputImagePath.slice(0, -outputExtension.length);
   const rawExtension = getTutorialShotFileExtension(manifest.rawImagePath);
-  const existingContentPaths = new Set(
-    sourceState.allFiles.map((filePath) => normalizePosixPath(path.relative(sourceRoot, filePath))),
+  const existingArtifactIdentities = new Set(
+    sourceState.allFiles.map((absolutePath) =>
+      getFileSystemPathIdentity({ sourceRoot, absolutePath }),
+    ),
   );
+  for (const artifactPaths of sourceState.artifactPathsByReferenceKey.values()) {
+    for (const contentRelativePath of Object.values(artifactPaths)) {
+      existingArtifactIdentities.add(
+        getTutorialShotArtifactIdentity({ sourceRoot, contentRelativePath }),
+      );
+    }
+  }
 
   for (let attempt = 0; attempt < 128; attempt += 1) {
     const suffix = randomBytes(3).toString("hex");
@@ -754,17 +872,17 @@ const allocateBranchedTutorialShotPaths = ({ sourceRoot, sourceState, manifest }
       0,
       derived.rawImagePath.length - getTutorialShotFileExtension(derived.rawImagePath).length,
     );
-    const collidesWithReference = sourceState.refs.some(
-      (ref) =>
-        ref.referencedImagePath === derived.outputImagePath ||
-        ref.outputImagePath === derived.outputImagePath ||
-        ref.id === derived.id,
+    const candidatePaths = [
+      derived.outputImagePath,
+      derived.manifestPath,
+      ...TUTORIAL_SHOT_RAW_IMAGE_EXTENSIONS.map((extension) => `${rawStem}${extension}`),
+    ];
+    const collides = candidatePaths.some((contentRelativePath) =>
+      existingArtifactIdentities.has(
+        getTutorialShotArtifactIdentity({ sourceRoot, contentRelativePath }),
+      ),
     );
-    const collidesWithFile =
-      existingContentPaths.has(derived.outputImagePath) ||
-      existingContentPaths.has(derived.manifestPath) ||
-      [...existingContentPaths].some((contentPath) => contentPath.startsWith(`${rawStem}.`));
-    if (!collidesWithReference && !collidesWithFile) {
+    if (!collides) {
       return derived;
     }
   }
@@ -781,59 +899,105 @@ const replaceTutorialShotSourceRef = ({ sourceText, sourceRef, nextImg }) => {
   )}`;
 };
 
-const commitTutorialShotFiles = async (entries) => {
+const createTutorialShotFileOperationError = ({ action, filePath, error }) =>
+  new Error(`${action}: ${filePath}: ${error instanceof Error ? error.message : String(error)}`, {
+    cause: error,
+  });
+
+export const commitTutorialShotFiles = async (entries, { fileOps = fs } = {}) => {
   const transactionId = randomUUID();
   const staged = entries.map((entry, index) => ({
     ...entry,
     backupPath: `${entry.targetPath}.${transactionId}.${index}.bak`,
+    backupCreated: false,
     hadTarget: false,
     installed: false,
+    restored: false,
     temporaryPath: `${entry.targetPath}.${transactionId}.${index}.tmp`,
+    temporaryWritten: false,
   }));
-  let operationError = null;
-  const rollbackErrors = [];
 
   try {
     for (const entry of staged) {
-      await ensureParentDir(entry.targetPath);
-      await fs.writeFile(entry.temporaryPath, entry.data);
+      await ensureParentDir(entry.targetPath, fileOps);
+      entry.temporaryWritten = true;
+      await fileOps.writeFile(entry.temporaryPath, entry.data);
     }
     for (const entry of staged) {
-      entry.hadTarget = await resolveExistingFile(entry.targetPath);
+      entry.hadTarget = await resolveExistingFile(entry.targetPath, fileOps);
       if (entry.hadTarget) {
-        await fs.rename(entry.targetPath, entry.backupPath);
+        await fileOps.rename(entry.targetPath, entry.backupPath);
+        entry.backupCreated = true;
       }
-      await fs.rename(entry.temporaryPath, entry.targetPath);
+      await fileOps.rename(entry.temporaryPath, entry.targetPath);
+      entry.temporaryWritten = false;
       entry.installed = true;
     }
-  } catch (error) {
-    operationError = error;
+  } catch (operationError) {
+    const rollbackErrors = [];
     for (const entry of [...staged].reverse()) {
-      try {
-        if (entry.installed) {
-          await fs.rm(entry.targetPath, { force: true });
+      if (entry.installed) {
+        try {
+          await fileOps.rm(entry.targetPath, { force: true });
+          entry.installed = false;
+        } catch (rollbackError) {
+          rollbackErrors.push(
+            createTutorialShotFileOperationError({
+              action: "設置済みファイルをロールバックできませんでした",
+              filePath: entry.targetPath,
+              error: rollbackError,
+            }),
+          );
         }
-        if (entry.hadTarget && (await resolveExistingFile(entry.backupPath))) {
-          await fs.rename(entry.backupPath, entry.targetPath);
+      }
+      if (entry.backupCreated) {
+        try {
+          await fileOps.rename(entry.backupPath, entry.targetPath);
+          entry.backupCreated = false;
+          entry.restored = true;
+        } catch (rollbackError) {
+          rollbackErrors.push(
+            createTutorialShotFileOperationError({
+              action: "バックアップを復元できませんでした。手動復旧用バックアップを保持します",
+              filePath: entry.backupPath,
+              error: rollbackError,
+            }),
+          );
         }
-      } catch (rollbackError) {
-        rollbackErrors.push(rollbackError);
       }
     }
-  }
 
-  const cleanupErrors = [];
-  for (const entry of staged) {
-    for (const cleanupPath of [entry.temporaryPath, entry.backupPath]) {
-      try {
-        await fs.rm(cleanupPath, { force: true });
-      } catch (cleanupError) {
-        cleanupErrors.push(cleanupError);
+    const cleanupErrors = [];
+    for (const entry of staged) {
+      if (entry.temporaryWritten) {
+        try {
+          await fileOps.rm(entry.temporaryPath, { force: true });
+          entry.temporaryWritten = false;
+        } catch (cleanupError) {
+          cleanupErrors.push(
+            createTutorialShotFileOperationError({
+              action: "ロールバック後の一時ファイルを削除できませんでした",
+              filePath: entry.temporaryPath,
+              error: cleanupError,
+            }),
+          );
+        }
+      }
+      if (entry.restored) {
+        try {
+          await fileOps.rm(entry.backupPath, { force: true });
+        } catch (cleanupError) {
+          cleanupErrors.push(
+            createTutorialShotFileOperationError({
+              action: "復元済みバックアップを削除できませんでした",
+              filePath: entry.backupPath,
+              error: cleanupError,
+            }),
+          );
+        }
       }
     }
-  }
 
-  if (operationError) {
     if (rollbackErrors.length > 0 || cleanupErrors.length > 0) {
       throw new AggregateError(
         [operationError, ...rollbackErrors, ...cleanupErrors],
@@ -842,12 +1006,35 @@ const commitTutorialShotFiles = async (entries) => {
     }
     throw operationError;
   }
-  if (cleanupErrors.length > 0) {
-    throw new AggregateError(
-      cleanupErrors,
-      "チュートリアル画像は保存されましたが、一時ファイルを削除できませんでした。",
-    );
+
+  const cleanupWarnings = [];
+  for (const entry of staged) {
+    const cleanupPaths = [];
+    if (entry.temporaryWritten) {
+      cleanupPaths.push({ kind: "一時ファイル", path: entry.temporaryPath });
+    }
+    if (entry.backupCreated) {
+      cleanupPaths.push({ kind: "バックアップ", path: entry.backupPath });
+    }
+    for (const cleanup of cleanupPaths) {
+      try {
+        await fileOps.rm(cleanup.path, { force: true });
+        if (cleanup.path === entry.temporaryPath) {
+          entry.temporaryWritten = false;
+        } else {
+          entry.backupCreated = false;
+        }
+      } catch (cleanupError) {
+        cleanupWarnings.push(
+          `保存は完了しましたが、${cleanup.kind}を削除できませんでした: ${cleanup.path}: ${
+            cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+          }`,
+        );
+      }
+    }
   }
+
+  return { cleanupWarnings };
 };
 
 export const saveTutorialShot = async ({
@@ -858,6 +1045,7 @@ export const saveTutorialShot = async ({
   rawImageFileName = null,
   bootstrapFromOutput = false,
   bootstrapImagePath = null,
+  fileOps = fs,
 }) => {
   const sourceState = await scanTutorialShotSourceState({ sourceRoot });
   const { currentRef, page } = validateTutorialShotSourceRef({ sourceState, sourceRef });
@@ -886,10 +1074,18 @@ export const saveTutorialShot = async ({
   }
 
   const originalManifest = manifest;
-  const referencesToCurrentImage = sourceState.refs.filter(
-    (ref) => ref.referencedImagePath === currentRef.referencedImagePath,
+  const currentArtifactPaths = getTutorialShotArtifactPaths(manifest);
+  const shouldBranch = sourceState.refs.some((ref) =>
+    ref.referenceKey === currentRef.referenceKey
+      ? false
+      : tutorialShotArtifactPathsShareArtifacts({
+          sourceRoot,
+          leftPaths: currentArtifactPaths,
+          rightPaths:
+            sourceState.artifactPathsByReferenceKey.get(ref.referenceKey) ??
+            getTutorialShotArtifactPaths(ref),
+        }),
   );
-  const shouldBranch = referencesToCurrentImage.length > 1;
   if (shouldBranch) {
     const branchedPaths = allocateBranchedTutorialShotPaths({
       sourceRoot,
@@ -1165,12 +1361,15 @@ export const saveTutorialShot = async ({
       data: rawBuffer,
     });
   }
-  await commitTutorialShotFiles(fileEntries);
+  const { cleanupWarnings } = await commitTutorialShotFiles(fileEntries, { fileOps });
 
   return {
     manifest: savedManifest,
     sourceRef: nextSourceRef,
-    warnings: getTutorialShotWarnings(savedManifest, { shotSource: currentRef.shotSource }),
+    warnings: [
+      ...getTutorialShotWarnings(savedManifest, { shotSource: currentRef.shotSource }),
+      ...cleanupWarnings,
+    ],
   };
 };
 

--- a/src/lib/tutorial-shots-server.mjs
+++ b/src/lib/tutorial-shots-server.mjs
@@ -1,3 +1,4 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import sharp from "sharp";
@@ -12,6 +13,7 @@ import {
   getTutorialShotCanvasLayout,
   getTutorialShotGeneratedImageFormat,
   getTutorialShotImageContentType,
+  getTutorialShotPageRelativeOutputImagePath,
   getTutorialShotSourceImageExtensionForFileName,
   getTutorialShotSourceImageExtensionForMimeType,
   getTutorialShotWarnings,
@@ -25,7 +27,6 @@ import {
   replaceTutorialShotPathExtension,
   renderTutorialShotOverlaySvg,
   isTutorialShotSourceImageMimeType,
-  rewriteTutorialShotImageRefsForOutputPolicy,
 } from "./tutorial-shots-shared.mjs";
 
 const PAGE_PATH_PATTERN = /^content\/.+\/index\.mdx?$/iu;
@@ -179,23 +180,6 @@ const ensureParentDir = async (filePath) => {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
 };
 
-const rewritePageSourceForDevRefresh = async ({
-  pageAbsPath,
-  pagePath,
-  sourceText,
-  outputImagePath,
-}) => {
-  // Rewriting the page with identical contents makes the synced MDX page update
-  // after the generated image file, so the open dev preview reloads the latest image.
-  const rewrite = rewriteTutorialShotImageRefsForOutputPolicy({
-    pagePath,
-    sourceText,
-    outputImagePath,
-  });
-  await fs.writeFile(pageAbsPath, rewrite.sourceText, "utf8");
-  return rewrite.sourceText;
-};
-
 const hydrateManifest = (manifestInput) => {
   const normalized = normalizeTutorialShotManifest(manifestInput);
   const defaults = createDefaultTutorialShotManifest({
@@ -323,27 +307,24 @@ const getRawUploadExtensionForMetadata = ({
   return [...acceptedExtensions][0];
 };
 
-const writeGeneratedTutorialShotImage = async ({ image, outputAbsPath, outputFormat }) => {
+const renderGeneratedTutorialShotImage = async ({ image, outputImagePath, outputFormat }) => {
   if (!outputFormat) {
-    throw new Error(`出力画像の形式が対応していません: ${outputAbsPath}`);
+    throw new Error(`出力画像の形式が対応していません: ${outputImagePath}`);
   }
 
   if (outputFormat.sharpFormat === "webp-lossless") {
-    await image.webp({ lossless: true }).toFile(outputAbsPath);
-    return;
+    return image.webp({ lossless: true }).toBuffer();
   }
 
   if (outputFormat.sharpFormat === "png") {
-    await image.png().toFile(outputAbsPath);
-    return;
+    return image.png().toBuffer();
   }
 
   if (outputFormat.sharpFormat === "jpeg") {
-    await image.jpeg().toFile(outputAbsPath);
-    return;
+    return image.jpeg().toBuffer();
   }
 
-  throw new Error(`出力画像の形式が対応していません: ${outputAbsPath}`);
+  throw new Error(`出力画像の形式が対応していません: ${outputImagePath}`);
 };
 
 const normalizeCrop = ({ crop, width, height }) => {
@@ -391,12 +372,11 @@ const getRepeatedOverlayComposites = ({ overlaySvg, pages, pageHeight }) =>
     top: index * pageHeight,
   }));
 
-const writeAnimatedWebpTutorialShotImage = async ({
+const renderAnimatedWebpTutorialShotImage = async ({
   rawBuffer,
   crop,
   outputLayout,
   overlaySvg,
-  outputAbsPath,
   animatedOutputPlan,
 }) => {
   const webpOptions = { lossless: true };
@@ -407,7 +387,7 @@ const writeAnimatedWebpTutorialShotImage = async ({
     webpOptions.loop = animatedOutputPlan.loop;
   }
 
-  await sharp(rawBuffer, { animated: true, limitInputPixels: SHARP_INPUT_PIXEL_LIMIT })
+  return sharp(rawBuffer, { animated: true, limitInputPixels: SHARP_INPUT_PIXEL_LIMIT })
     .extract({
       left: crop.x,
       top: crop.y,
@@ -434,7 +414,7 @@ const writeAnimatedWebpTutorialShotImage = async ({
       }),
     )
     .webp(webpOptions)
-    .toFile(outputAbsPath);
+    .toBuffer();
 };
 
 /**
@@ -509,122 +489,378 @@ export const getTutorialShotAuthoringContext = async ({
   };
 };
 
-export const scanTutorialShots = async ({ sourceRoot }) => {
+const hashTutorialShotText = (value) => createHash("sha256").update(value, "utf8").digest("hex");
+
+const createTutorialShotReferenceKey = ({ pagePath, pageRevision, tagName, tagStart, tagEnd }) =>
+  hashTutorialShotText(
+    JSON.stringify([pagePath, pageRevision, tagName, Number(tagStart), Number(tagEnd)]),
+  );
+
+const extractTutorialShotSourceRefs = ({ pagePath, sourceText }) => {
+  const pageRevision = hashTutorialShotText(sourceText);
+  return [
+    ...extractActionImageRefsFromMdx({ pagePath, sourceText }).map((ref) => ({
+      ...ref,
+      shotSource: "action",
+    })),
+    ...extractVerifyImageRefsFromMdx({ pagePath, sourceText }).map((ref) => ({
+      ...ref,
+      shotSource: "verify",
+    })),
+  ].map((ref) => ({
+    ...ref,
+    pageRevision,
+    referenceKey: createTutorialShotReferenceKey({ ...ref, pageRevision }),
+  }));
+};
+
+const scanTutorialShotSourceState = async ({ sourceRoot }) => {
   const contentRoot = path.join(sourceRoot, "content");
   const allFiles = await enumerateFiles(contentRoot);
   const pageFiles = allFiles.filter((filePath) => {
     const relativePath = normalizePosixPath(path.relative(sourceRoot, filePath));
     return PAGE_PATH_PATTERN.test(relativePath);
   });
-  const shots = [];
+  const pages = new Map();
+  const refs = [];
 
   for (const filePath of pageFiles) {
     const relativePath = normalizePosixPath(path.relative(sourceRoot, filePath));
     const sourceText = await fs.readFile(filePath, "utf8");
-    const refs = [
-      ...extractActionImageRefsFromMdx({ pagePath: relativePath, sourceText }).map((ref) => ({
-        ...ref,
-        shotSource: "action",
-      })),
-      ...extractVerifyImageRefsFromMdx({ pagePath: relativePath, sourceText }).map((ref) => ({
-        ...ref,
-        shotSource: "verify",
-      })),
-    ];
-
-    for (const ref of refs) {
-      const manifestPath = resolveSourcePath({
-        sourceRoot,
-        contentRelativePath: ref.manifestPath,
-        validator: isTutorialShotManifestPath,
-      });
-      const outputImagePath = resolveSourcePath({
-        sourceRoot,
-        contentRelativePath: ref.outputImagePath,
-        validator: isTutorialShotOutputImagePath,
-      });
-      const referencedImagePath = resolveSourcePath({
-        sourceRoot,
-        contentRelativePath: ref.referencedImagePath,
-        validator: isTutorialShotReadableImagePath,
-      });
-
-      const rawManifest = await readJsonIfExists(manifestPath);
-      const manifest = hydrateManifest(
-        rawManifest
-          ? {
-              ...rawManifest,
-              pagePath: ref.pagePath,
-              outputImagePath: ref.outputImagePath,
-            }
-          : createDefaultTutorialShotManifest({
-              pagePath: ref.pagePath,
-              outputImagePath: ref.outputImagePath,
-            }),
-      );
-      const rawImagePath = resolveSourcePath({
-        sourceRoot,
-        contentRelativePath: manifest.rawImagePath,
-        validator: (contentPath) =>
-          isExpectedTutorialShotRawImagePath({
-            pagePath: manifest.pagePath,
-            outputImagePath: manifest.outputImagePath,
-            rawImagePath: contentPath,
-          }),
-      });
-
-      const warnings = getTutorialShotWarnings(manifest, { shotSource: ref.shotSource });
-      const hasManifest = rawManifest !== null;
-      const hasRawImage = await fs
-        .stat(rawImagePath)
-        .then(() => true)
-        .catch(() => false);
-      const hasOutputImage = await fs
-        .stat(outputImagePath)
-        .then(() => true)
-        .catch(() => false);
-      const hasReferencedImage =
-        ref.referencedImagePath === ref.outputImagePath
-          ? hasOutputImage
-          : await fs
-              .stat(referencedImagePath)
-              .then(() => true)
-              .catch(() => false);
-      const bootstrapImagePath = hasOutputImage
-        ? ref.outputImagePath
-        : hasReferencedImage
-          ? ref.referencedImagePath
-          : null;
-
-      shots.push({
-        ...ref,
-        rawImagePath: manifest.rawImagePath,
-        manifest,
-        warnings,
-        hasManifest,
-        hasRawImage,
-        hasOutputImage: hasOutputImage || hasReferencedImage,
-        bootstrapImagePath,
-      });
-    }
+    const pageRevision = hashTutorialShotText(sourceText);
+    pages.set(relativePath, { absolutePath: filePath, pageRevision, sourceText });
+    refs.push(...extractTutorialShotSourceRefs({ pagePath: relativePath, sourceText }));
   }
 
-  return shots.sort((left, right) => {
+  refs.sort((left, right) => {
     if (left.pagePath !== right.pagePath) {
       return left.pagePath.localeCompare(right.pagePath);
     }
-    return left.line - right.line;
+    return left.tagStart - right.tagStart;
   });
+
+  return {
+    allFiles,
+    pages,
+    refs,
+  };
+};
+
+export const scanTutorialShots = async ({ sourceRoot }) => {
+  const sourceState = await scanTutorialShotSourceState({ sourceRoot });
+  const shots = [];
+
+  for (const ref of sourceState.refs) {
+    const manifestPath = resolveSourcePath({
+      sourceRoot,
+      contentRelativePath: ref.manifestPath,
+      validator: isTutorialShotManifestPath,
+    });
+    const outputImagePath = resolveSourcePath({
+      sourceRoot,
+      contentRelativePath: ref.outputImagePath,
+      validator: isTutorialShotOutputImagePath,
+    });
+    const referencedImagePath = resolveSourcePath({
+      sourceRoot,
+      contentRelativePath: ref.referencedImagePath,
+      validator: isTutorialShotReadableImagePath,
+    });
+
+    const rawManifest = await readJsonIfExists(manifestPath);
+    const manifest = hydrateManifest(
+      rawManifest
+        ? {
+            ...rawManifest,
+            pagePath: ref.pagePath,
+            outputImagePath: ref.outputImagePath,
+          }
+        : createDefaultTutorialShotManifest({
+            pagePath: ref.pagePath,
+            outputImagePath: ref.outputImagePath,
+          }),
+    );
+    const rawImagePath = resolveSourcePath({
+      sourceRoot,
+      contentRelativePath: manifest.rawImagePath,
+      validator: (contentPath) =>
+        isExpectedTutorialShotRawImagePath({
+          pagePath: manifest.pagePath,
+          outputImagePath: manifest.outputImagePath,
+          rawImagePath: contentPath,
+        }),
+    });
+
+    const warnings = getTutorialShotWarnings(manifest, { shotSource: ref.shotSource });
+    const hasManifest = rawManifest !== null;
+    const hasRawImage = await fs
+      .stat(rawImagePath)
+      .then(() => true)
+      .catch(() => false);
+    const hasOutputImage = await fs
+      .stat(outputImagePath)
+      .then(() => true)
+      .catch(() => false);
+    const hasReferencedImage =
+      ref.referencedImagePath === ref.outputImagePath
+        ? hasOutputImage
+        : await fs
+            .stat(referencedImagePath)
+            .then(() => true)
+            .catch(() => false);
+    const bootstrapImagePath = hasOutputImage
+      ? ref.outputImagePath
+      : hasReferencedImage
+        ? ref.referencedImagePath
+        : null;
+
+    shots.push({
+      ...ref,
+      rawImagePath: manifest.rawImagePath,
+      manifest,
+      warnings,
+      hasManifest,
+      hasRawImage,
+      hasOutputImage: hasOutputImage || hasReferencedImage,
+      bootstrapImagePath,
+    });
+  }
+
+  return shots;
+};
+
+const SOURCE_REFERENCE_CONFLICT_MESSAGE =
+  "教材が更新されています。一覧を再読み込みしてから、もう一度保存してください。";
+
+export class TutorialShotConflictError extends Error {
+  constructor(message = SOURCE_REFERENCE_CONFLICT_MESSAGE) {
+    super(message);
+    this.name = "TutorialShotConflictError";
+    this.statusCode = 409;
+  }
+}
+
+const throwTutorialShotConflict = () => {
+  throw new TutorialShotConflictError();
+};
+
+const validateTutorialShotSourceRef = ({ sourceState, sourceRef }) => {
+  if (!sourceRef || typeof sourceRef !== "object") {
+    throwTutorialShotConflict();
+  }
+
+  const pagePath = normalizePosixPath(sourceRef.pagePath ?? "");
+  if (pagePath !== sourceRef.pagePath || !PAGE_PATH_PATTERN.test(pagePath)) {
+    throwTutorialShotConflict();
+  }
+  if (sourceRef.tagName !== "Action" && sourceRef.tagName !== "Verify") {
+    throwTutorialShotConflict();
+  }
+  for (const field of ["tagStart", "tagEnd", "imgValueStart", "imgValueEnd"]) {
+    if (!Number.isSafeInteger(sourceRef[field])) {
+      throwTutorialShotConflict();
+    }
+  }
+  if (
+    typeof sourceRef.expectedImg !== "string" ||
+    typeof sourceRef.pageRevision !== "string" ||
+    typeof sourceRef.referenceKey !== "string"
+  ) {
+    throwTutorialShotConflict();
+  }
+
+  const page = sourceState.pages.get(pagePath);
+  if (!page || page.pageRevision !== sourceRef.pageRevision) {
+    throwTutorialShotConflict();
+  }
+  if (
+    sourceRef.tagStart < 0 ||
+    sourceRef.tagEnd <= sourceRef.tagStart ||
+    sourceRef.tagEnd > page.sourceText.length ||
+    sourceRef.imgValueStart < sourceRef.tagStart ||
+    sourceRef.imgValueEnd < sourceRef.imgValueStart ||
+    sourceRef.imgValueEnd > sourceRef.tagEnd ||
+    page.sourceText.slice(sourceRef.imgValueStart, sourceRef.imgValueEnd) !== sourceRef.expectedImg
+  ) {
+    throwTutorialShotConflict();
+  }
+
+  const expectedReferenceKey = createTutorialShotReferenceKey(sourceRef);
+  if (expectedReferenceKey !== sourceRef.referenceKey) {
+    throwTutorialShotConflict();
+  }
+
+  const currentRef = sourceState.refs.find(
+    (ref) =>
+      ref.pagePath === pagePath &&
+      ref.tagName === sourceRef.tagName &&
+      ref.tagStart === sourceRef.tagStart &&
+      ref.tagEnd === sourceRef.tagEnd &&
+      ref.imgValueStart === sourceRef.imgValueStart &&
+      ref.imgValueEnd === sourceRef.imgValueEnd &&
+      ref.expectedImg === sourceRef.expectedImg &&
+      ref.pageRevision === sourceRef.pageRevision &&
+      ref.referenceKey === sourceRef.referenceKey,
+  );
+  if (!currentRef) {
+    throwTutorialShotConflict();
+  }
+
+  return { currentRef, page };
+};
+
+const assertTutorialShotSourceStateUnchanged = async ({ sourceRoot, sourceState }) => {
+  const currentState = await scanTutorialShotSourceState({ sourceRoot });
+  if (currentState.pages.size !== sourceState.pages.size) {
+    throwTutorialShotConflict();
+  }
+
+  for (const [pagePath, page] of sourceState.pages) {
+    if (currentState.pages.get(pagePath)?.pageRevision !== page.pageRevision) {
+      throwTutorialShotConflict();
+    }
+  }
+};
+
+const resolveExistingFile = async (filePath) => {
+  try {
+    const stats = await fs.stat(filePath);
+    return stats.isFile();
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+};
+
+const allocateBranchedTutorialShotPaths = ({ sourceRoot, sourceState, manifest }) => {
+  const outputExtension = path.posix.extname(manifest.outputImagePath);
+  const outputStem = manifest.outputImagePath.slice(0, -outputExtension.length);
+  const rawExtension = getTutorialShotFileExtension(manifest.rawImagePath);
+  const existingContentPaths = new Set(
+    sourceState.allFiles.map((filePath) => normalizePosixPath(path.relative(sourceRoot, filePath))),
+  );
+
+  for (let attempt = 0; attempt < 128; attempt += 1) {
+    const suffix = randomBytes(3).toString("hex");
+    const outputImagePath = `${outputStem}--${suffix}${outputExtension}`;
+    const derived = deriveTutorialShotPaths({
+      pagePath: manifest.pagePath,
+      outputImagePath,
+      rawImageExtension: rawExtension,
+    });
+    const rawStem = derived.rawImagePath.slice(
+      0,
+      derived.rawImagePath.length - getTutorialShotFileExtension(derived.rawImagePath).length,
+    );
+    const collidesWithReference = sourceState.refs.some(
+      (ref) =>
+        ref.referencedImagePath === derived.outputImagePath ||
+        ref.outputImagePath === derived.outputImagePath ||
+        ref.id === derived.id,
+    );
+    const collidesWithFile =
+      existingContentPaths.has(derived.outputImagePath) ||
+      existingContentPaths.has(derived.manifestPath) ||
+      [...existingContentPaths].some((contentPath) => contentPath.startsWith(`${rawStem}.`));
+    if (!collidesWithReference && !collidesWithFile) {
+      return derived;
+    }
+  }
+
+  throw new Error("重複しないチュートリアル画像パスを作成できませんでした。");
+};
+
+const replaceTutorialShotSourceRef = ({ sourceText, sourceRef, nextImg }) => {
+  if (sourceText.slice(sourceRef.imgValueStart, sourceRef.imgValueEnd) !== sourceRef.expectedImg) {
+    throwTutorialShotConflict();
+  }
+  return `${sourceText.slice(0, sourceRef.imgValueStart)}${nextImg}${sourceText.slice(
+    sourceRef.imgValueEnd,
+  )}`;
+};
+
+const commitTutorialShotFiles = async (entries) => {
+  const transactionId = randomUUID();
+  const staged = entries.map((entry, index) => ({
+    ...entry,
+    backupPath: `${entry.targetPath}.${transactionId}.${index}.bak`,
+    hadTarget: false,
+    installed: false,
+    temporaryPath: `${entry.targetPath}.${transactionId}.${index}.tmp`,
+  }));
+  let operationError = null;
+  const rollbackErrors = [];
+
+  try {
+    for (const entry of staged) {
+      await ensureParentDir(entry.targetPath);
+      await fs.writeFile(entry.temporaryPath, entry.data);
+    }
+    for (const entry of staged) {
+      entry.hadTarget = await resolveExistingFile(entry.targetPath);
+      if (entry.hadTarget) {
+        await fs.rename(entry.targetPath, entry.backupPath);
+      }
+      await fs.rename(entry.temporaryPath, entry.targetPath);
+      entry.installed = true;
+    }
+  } catch (error) {
+    operationError = error;
+    for (const entry of [...staged].reverse()) {
+      try {
+        if (entry.installed) {
+          await fs.rm(entry.targetPath, { force: true });
+        }
+        if (entry.hadTarget && (await resolveExistingFile(entry.backupPath))) {
+          await fs.rename(entry.backupPath, entry.targetPath);
+        }
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+  }
+
+  const cleanupErrors = [];
+  for (const entry of staged) {
+    for (const cleanupPath of [entry.temporaryPath, entry.backupPath]) {
+      try {
+        await fs.rm(cleanupPath, { force: true });
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    }
+  }
+
+  if (operationError) {
+    if (rollbackErrors.length > 0 || cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [operationError, ...rollbackErrors, ...cleanupErrors],
+        "チュートリアル画像の保存に失敗し、元のファイル状態を完全には復元できませんでした。",
+      );
+    }
+    throw operationError;
+  }
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(
+      cleanupErrors,
+      "チュートリアル画像は保存されましたが、一時ファイルを削除できませんでした。",
+    );
+  }
 };
 
 export const saveTutorialShot = async ({
   sourceRoot,
+  sourceRef,
   manifestInput,
   rawImageDataUrl = null,
   rawImageFileName = null,
   bootstrapFromOutput = false,
   bootstrapImagePath = null,
 }) => {
+  const sourceState = await scanTutorialShotSourceState({ sourceRoot });
+  const { currentRef, page } = validateTutorialShotSourceRef({ sourceState, sourceRef });
   let manifest = prepareManifestForSave(manifestInput);
   const annotationErrors = getTutorialShotAnnotationErrors(
     manifest.annotations,
@@ -637,13 +873,148 @@ export const saveTutorialShot = async ({
   if (!PAGE_PATH_PATTERN.test(manifest.pagePath)) {
     throw new Error(`不正なチュートリアル画像ページパスです: ${manifest.pagePath}`);
   }
+  const referencedPaths = deriveTutorialShotPaths({
+    pagePath: currentRef.pagePath,
+    outputImagePath: currentRef.referencedImagePath,
+    rawImageExtension: getTutorialShotFileExtension(currentRef.referencedImagePath),
+  });
+  if (
+    manifest.pagePath !== currentRef.pagePath ||
+    manifest.outputImagePath !== referencedPaths.outputImagePath
+  ) {
+    throwTutorialShotConflict();
+  }
+
+  const originalManifest = manifest;
+  const referencesToCurrentImage = sourceState.refs.filter(
+    (ref) => ref.referencedImagePath === currentRef.referencedImagePath,
+  );
+  const shouldBranch = referencesToCurrentImage.length > 1;
+  if (shouldBranch) {
+    const branchedPaths = allocateBranchedTutorialShotPaths({
+      sourceRoot,
+      sourceState,
+      manifest,
+    });
+    manifest = {
+      ...manifest,
+      id: branchedPaths.id,
+      outputImagePath: branchedPaths.outputImagePath,
+      rawImagePath: branchedPaths.rawImagePath,
+    };
+  }
+
+  const originalRawAbsPath = resolveSourcePath({
+    sourceRoot,
+    contentRelativePath: originalManifest.rawImagePath,
+    validator: (contentPath) =>
+      isExpectedTutorialShotRawImagePath({
+        pagePath: originalManifest.pagePath,
+        outputImagePath: originalManifest.outputImagePath,
+        rawImagePath: contentPath,
+      }),
+  });
+  const originalRawExists = await resolveExistingFile(originalRawAbsPath);
+  let rawBuffer = null;
+  let shouldWriteRawImage = false;
+
+  if (rawImageDataUrl) {
+    const { buffer, mimeType } = parseDataUrl(rawImageDataUrl);
+    const metadata = await validateUploadedRawImageBuffer({ buffer });
+    const rawExtension = getRawUploadExtensionForMetadata({
+      metadataFormat: metadata.format,
+      mimeType,
+      rawImageFileName,
+      manifestRawImagePath: manifest.rawImagePath,
+    });
+    manifest = {
+      ...manifest,
+      rawImagePath: deriveTutorialShotRawImagePath({
+        pagePath: manifest.pagePath,
+        outputImagePath: manifest.outputImagePath,
+        fallbackExtension: rawExtension,
+      }),
+    };
+    rawBuffer = buffer;
+    shouldWriteRawImage = true;
+  } else if (originalRawExists) {
+    rawBuffer = await fs.readFile(originalRawAbsPath);
+    if (shouldBranch) {
+      manifest = {
+        ...manifest,
+        rawImagePath: deriveTutorialShotRawImagePath({
+          pagePath: manifest.pagePath,
+          outputImagePath: manifest.outputImagePath,
+          fallbackExtension: getTutorialShotFileExtension(originalManifest.rawImagePath),
+        }),
+      };
+      shouldWriteRawImage = true;
+    }
+  } else if (shouldBranch || bootstrapFromOutput) {
+    const requestedBootstrapPath =
+      typeof bootstrapImagePath === "string" && bootstrapImagePath.trim()
+        ? normalizeDecodedPosixPath(bootstrapImagePath)
+        : null;
+    const bootstrapCandidates = shouldBranch
+      ? [currentRef.referencedImagePath, originalManifest.outputImagePath, requestedBootstrapPath]
+      : [requestedBootstrapPath, originalManifest.outputImagePath];
+    const legacyExtension = getTutorialShotFileExtension(originalManifest.rawImagePath);
+    if (!requestedBootstrapPath && legacyExtension) {
+      bootstrapCandidates.push(
+        replaceTutorialShotPathExtension(originalManifest.outputImagePath, legacyExtension),
+      );
+    }
+
+    let resolvedBootstrap = null;
+    for (const candidate of [...new Set(bootstrapCandidates.filter(Boolean))]) {
+      const candidateAbsPath = resolveSourcePath({
+        sourceRoot,
+        contentRelativePath: candidate,
+        validator: isTutorialShotReadableImagePath,
+      });
+      if (!shouldBranch) {
+        const candidatePaths = deriveTutorialShotPaths({
+          pagePath: originalManifest.pagePath,
+          outputImagePath: candidate,
+        });
+        if (candidatePaths.id !== originalManifest.id) {
+          throw new Error("現在の出力画像と保存対象のショットが一致しません。");
+        }
+      }
+      if (await resolveExistingFile(candidateAbsPath)) {
+        resolvedBootstrap = { absolutePath: candidateAbsPath, contentPath: candidate };
+        break;
+      }
+    }
+    if (!resolvedBootstrap) {
+      throw new Error(
+        "現在の出力画像が無いため、そこから元画像を初期作成できません。先に元画像をアップロードしてください。",
+      );
+    }
+    manifest = {
+      ...manifest,
+      rawImagePath: deriveTutorialShotRawImagePath({
+        pagePath: manifest.pagePath,
+        outputImagePath: manifest.outputImagePath,
+        fallbackExtension: getTutorialShotFileExtension(resolvedBootstrap.contentPath),
+      }),
+    };
+    rawBuffer = await fs.readFile(resolvedBootstrap.absolutePath);
+    shouldWriteRawImage = true;
+  }
+
+  if (!rawBuffer) {
+    throw new Error(
+      "元画像がまだ無いため、この Action 画像は保存できません。先に元画像をアップロードしてください。",
+    );
+  }
 
   const outputAbsPath = resolveSourcePath({
     sourceRoot,
     contentRelativePath: manifest.outputImagePath,
     validator: isTutorialShotOutputImagePath,
   });
-  let rawAbsPath = resolveSourcePath({
+  const rawAbsPath = resolveSourcePath({
     sourceRoot,
     contentRelativePath: manifest.rawImagePath,
     validator: (contentPath) =>
@@ -667,124 +1038,6 @@ export const saveTutorialShot = async ({
     contentRelativePath: manifest.pagePath,
     validator: PAGE_PATH_PATTERN,
   });
-
-  if (rawImageDataUrl) {
-    const { buffer, mimeType } = parseDataUrl(rawImageDataUrl);
-    const metadata = await validateUploadedRawImageBuffer({ buffer });
-    const rawExtension = getRawUploadExtensionForMetadata({
-      metadataFormat: metadata.format,
-      mimeType,
-      rawImageFileName,
-      manifestRawImagePath: manifest.rawImagePath,
-    });
-    manifest = {
-      ...manifest,
-      rawImagePath: deriveTutorialShotRawImagePath({
-        pagePath: manifest.pagePath,
-        outputImagePath: manifest.outputImagePath,
-        fallbackExtension: rawExtension,
-      }),
-    };
-    rawAbsPath = resolveSourcePath({
-      sourceRoot,
-      contentRelativePath: manifest.rawImagePath,
-      validator: (contentPath) =>
-        isExpectedTutorialShotRawImagePath({
-          pagePath: manifest.pagePath,
-          outputImagePath: manifest.outputImagePath,
-          rawImagePath: contentPath,
-        }),
-    });
-    await ensureParentDir(rawAbsPath);
-    await fs.writeFile(rawAbsPath, buffer);
-  } else if (bootstrapFromOutput) {
-    let bootstrapContentPath = normalizeDecodedPosixPath(
-      typeof bootstrapImagePath === "string" && bootstrapImagePath.trim()
-        ? bootstrapImagePath
-        : manifest.outputImagePath,
-    );
-    let bootstrapDerivedPaths = deriveTutorialShotPaths({
-      pagePath: manifest.pagePath,
-      outputImagePath: bootstrapContentPath,
-    });
-    if (bootstrapDerivedPaths.id !== manifest.id) {
-      throw new Error("現在の出力画像と保存対象のショットが一致しません。");
-    }
-    let bootstrapAbsPath = resolveSourcePath({
-      sourceRoot,
-      contentRelativePath: bootstrapContentPath,
-      validator: isTutorialShotReadableImagePath,
-    });
-    let bootstrapImageExists = await fs
-      .stat(bootstrapAbsPath)
-      .then(() => true)
-      .catch(() => false);
-    if (
-      !bootstrapImageExists &&
-      !(typeof bootstrapImagePath === "string" && bootstrapImagePath.trim())
-    ) {
-      const legacyExtension = getTutorialShotFileExtension(manifest.rawImagePath);
-      const legacyContentPath = legacyExtension
-        ? replaceTutorialShotPathExtension(manifest.outputImagePath, legacyExtension)
-        : manifest.outputImagePath;
-      if (legacyContentPath !== manifest.outputImagePath) {
-        bootstrapContentPath = legacyContentPath;
-        bootstrapDerivedPaths = deriveTutorialShotPaths({
-          pagePath: manifest.pagePath,
-          outputImagePath: bootstrapContentPath,
-        });
-        if (bootstrapDerivedPaths.id !== manifest.id) {
-          throw new Error("現在の出力画像と保存対象のショットが一致しません。");
-        }
-        bootstrapAbsPath = resolveSourcePath({
-          sourceRoot,
-          contentRelativePath: bootstrapContentPath,
-          validator: isTutorialShotReadableImagePath,
-        });
-        bootstrapImageExists = await fs
-          .stat(bootstrapAbsPath)
-          .then(() => true)
-          .catch(() => false);
-      }
-    }
-    manifest = {
-      ...manifest,
-      rawImagePath: deriveTutorialShotRawImagePath({
-        pagePath: manifest.pagePath,
-        outputImagePath: manifest.outputImagePath,
-        fallbackExtension: getTutorialShotFileExtension(bootstrapContentPath),
-      }),
-    };
-    rawAbsPath = resolveSourcePath({
-      sourceRoot,
-      contentRelativePath: manifest.rawImagePath,
-      validator: (contentPath) =>
-        isExpectedTutorialShotRawImagePath({
-          pagePath: manifest.pagePath,
-          outputImagePath: manifest.outputImagePath,
-          rawImagePath: contentPath,
-        }),
-    });
-    if (!bootstrapImageExists) {
-      throw new Error(
-        "現在の出力画像が無いため、そこから元画像を初期作成できません。先に元画像をアップロードしてください。",
-      );
-    }
-    await ensureParentDir(rawAbsPath);
-    await fs.copyFile(bootstrapAbsPath, rawAbsPath);
-  }
-
-  const rawExists = await fs
-    .stat(rawAbsPath)
-    .then(() => true)
-    .catch(() => false);
-  if (!rawExists) {
-    throw new Error(
-      "元画像がまだ無いため、この Action 画像は保存できません。先に元画像をアップロードしてください。",
-    );
-  }
-
-  const rawBuffer = await fs.readFile(rawAbsPath);
   const outputFormat = getTutorialShotGeneratedImageFormat(manifest.outputImagePath);
   const rawImageContext = await getRawImageProcessingContext({ rawBuffer });
   const { image: rawImage, metadata } = rawImageContext;
@@ -817,14 +1070,13 @@ export const saveTutorialShot = async ({
     offsetY: outputLayout.imageY,
   });
 
-  await ensureParentDir(outputAbsPath);
+  let outputBuffer;
   if (animatedOutputPlan) {
-    await writeAnimatedWebpTutorialShotImage({
+    outputBuffer = await renderAnimatedWebpTutorialShotImage({
       rawBuffer,
       crop,
       outputLayout,
       overlaySvg,
-      outputAbsPath,
       animatedOutputPlan,
     });
   } else {
@@ -858,9 +1110,9 @@ export const saveTutorialShot = async ({
       },
       { input: Buffer.from(overlaySvg, "utf8") },
     ]);
-    await writeGeneratedTutorialShotImage({
+    outputBuffer = await renderGeneratedTutorialShotImage({
       image: generatedImage,
-      outputAbsPath,
+      outputImagePath: manifest.outputImagePath,
       outputFormat,
     });
   }
@@ -870,20 +1122,55 @@ export const saveTutorialShot = async ({
     crop,
   };
 
-  await ensureParentDir(manifestAbsPath);
-  await fs.writeFile(manifestAbsPath, `${JSON.stringify(savedManifest, null, 2)}\n`, "utf8");
-
-  const pageSourceText = await fs.readFile(pageAbsPath, "utf8");
-  await rewritePageSourceForDevRefresh({
-    pageAbsPath,
+  const pageRelativeOutputImagePath = getTutorialShotPageRelativeOutputImagePath({
     pagePath: manifest.pagePath,
-    sourceText: pageSourceText,
     outputImagePath: manifest.outputImagePath,
   });
+  const nextPageSourceText = replaceTutorialShotSourceRef({
+    sourceText: page.sourceText,
+    sourceRef,
+    nextImg: pageRelativeOutputImagePath,
+  });
+  const nextSourceRef = extractTutorialShotSourceRefs({
+    pagePath: manifest.pagePath,
+    sourceText: nextPageSourceText,
+  }).find(
+    (ref) =>
+      ref.tagName === sourceRef.tagName &&
+      ref.tagStart === sourceRef.tagStart &&
+      ref.expectedImg === pageRelativeOutputImagePath,
+  );
+  if (!nextSourceRef) {
+    throw new Error("保存後のチュートリアル画像参照を特定できませんでした。");
+  }
+
+  await assertTutorialShotSourceStateUnchanged({ sourceRoot, sourceState });
+  const fileEntries = [
+    {
+      targetPath: outputAbsPath,
+      data: outputBuffer,
+    },
+    {
+      targetPath: manifestAbsPath,
+      data: `${JSON.stringify(savedManifest, null, 2)}\n`,
+    },
+    {
+      targetPath: pageAbsPath,
+      data: nextPageSourceText,
+    },
+  ];
+  if (shouldWriteRawImage) {
+    fileEntries.unshift({
+      targetPath: rawAbsPath,
+      data: rawBuffer,
+    });
+  }
+  await commitTutorialShotFiles(fileEntries);
 
   return {
     manifest: savedManifest,
-    warnings: getTutorialShotWarnings(savedManifest),
+    sourceRef: nextSourceRef,
+    warnings: getTutorialShotWarnings(savedManifest, { shotSource: currentRef.shotSource }),
   };
 };
 

--- a/src/lib/tutorial-shots-shared.mjs
+++ b/src/lib/tutorial-shots-shared.mjs
@@ -440,7 +440,7 @@ export const getTutorialShotPageRelativeOutputImagePath = ({ pagePath, outputIma
 
 const isExternalImageSrc = (value) => /^(https?:)?\/\//iu.test(value);
 
-const extractImageRefsFromMdxTag = ({ pagePath, sourceText, tagPattern }) => {
+const extractImageRefsFromMdxTag = ({ pagePath, sourceText, tagName, tagPattern }) => {
   const normalizedPagePath = normalizePosixPath(pagePath);
   const pageDir = posixDirname(normalizedPagePath);
   const refs = [];
@@ -452,14 +452,21 @@ const extractImageRefsFromMdxTag = ({ pagePath, sourceText, tagPattern }) => {
       continue;
     }
 
-    const rawSrc = imgMatch[2]?.trim();
+    const expectedImg = imgMatch[2] ?? "";
+    const rawSrc = expectedImg.trim();
     if (!rawSrc || isExternalImageSrc(rawSrc)) {
       continue;
     }
 
+    const tagStart = match.index ?? 0;
+    const tagEnd = tagStart + tag.length;
+    const imgPropStart = imgMatch.index ?? 0;
+    const quoteStart = imgMatch[0].indexOf(imgMatch[1]);
+    const imgValueStart = tagStart + imgPropStart + quoteStart + 1;
+    const imgValueEnd = imgValueStart + expectedImg.length;
     const sourceImagePath = normalizeDecodedPosixPath(rawSrc);
     const referencedImagePath = normalizeDecodedPosixPath(joinPosixPath(pageDir, rawSrc));
-    const line = sourceText.slice(0, match.index ?? 0).split(/\r?\n/gu).length;
+    const line = sourceText.slice(0, tagStart).split(/\r?\n/gu).length;
     const derived = deriveTutorialShotPaths({
       pagePath: normalizedPagePath,
       outputImagePath: referencedImagePath,
@@ -470,6 +477,12 @@ const extractImageRefsFromMdxTag = ({ pagePath, sourceText, tagPattern }) => {
       id: derived.id,
       line,
       pagePath: normalizedPagePath,
+      tagName,
+      tagStart,
+      tagEnd,
+      imgValueStart,
+      imgValueEnd,
+      expectedImg,
       sourceImagePath,
       referencedImagePath,
       outputImagePath: derived.outputImagePath,
@@ -482,70 +495,20 @@ const extractImageRefsFromMdxTag = ({ pagePath, sourceText, tagPattern }) => {
 };
 
 export const extractActionImageRefsFromMdx = ({ pagePath, sourceText }) =>
-  extractImageRefsFromMdxTag({ pagePath, sourceText, tagPattern: ACTION_TAG_PATTERN });
+  extractImageRefsFromMdxTag({
+    pagePath,
+    sourceText,
+    tagName: "Action",
+    tagPattern: ACTION_TAG_PATTERN,
+  });
 
 export const extractVerifyImageRefsFromMdx = ({ pagePath, sourceText }) =>
-  extractImageRefsFromMdxTag({ pagePath, sourceText, tagPattern: VERIFY_TAG_PATTERN });
-
-export const rewriteTutorialShotImageRefsForOutputPolicy = ({
-  pagePath,
-  sourceText,
-  outputImagePath,
-}) => {
-  const normalizedPagePath = normalizePosixPath(pagePath);
-  const policyOutputPath = applyTutorialShotStaticRasterOutputPolicy(outputImagePath);
-  const pageDir = posixDirname(normalizedPagePath);
-  const targetId = deriveTutorialShotPaths({
-    pagePath: normalizedPagePath,
-    outputImagePath: policyOutputPath,
-  }).id;
-  const pageRelativeOutputPath = getTutorialShotPageRelativeOutputImagePath({
-    pagePath: normalizedPagePath,
-    outputImagePath: policyOutputPath,
+  extractImageRefsFromMdxTag({
+    pagePath,
+    sourceText,
+    tagName: "Verify",
+    tagPattern: VERIFY_TAG_PATTERN,
   });
-  let changed = false;
-
-  const replaceTag = (tag) => {
-    const imgMatch = IMG_PROP_PATTERN.exec(tag);
-    if (!imgMatch) {
-      return tag;
-    }
-
-    const rawSrc = imgMatch[2]?.trim();
-    if (!rawSrc || isExternalImageSrc(rawSrc)) {
-      return tag;
-    }
-
-    const currentImagePath = normalizeDecodedPosixPath(joinPosixPath(pageDir, rawSrc));
-    const currentId = deriveTutorialShotPaths({
-      pagePath: normalizedPagePath,
-      outputImagePath: currentImagePath,
-    }).id;
-    if (currentId !== targetId) {
-      return tag;
-    }
-
-    const quote = imgMatch[1];
-    const nextImgProp = `img=${quote}${pageRelativeOutputPath}${quote}`;
-    if (imgMatch[0] === nextImgProp) {
-      return tag;
-    }
-
-    changed = true;
-    return `${tag.slice(0, imgMatch.index)}${nextImgProp}${tag.slice(
-      imgMatch.index + imgMatch[0].length,
-    )}`;
-  };
-
-  const nextSourceText = sourceText
-    .replace(ACTION_TAG_PATTERN, replaceTag)
-    .replace(VERIFY_TAG_PATTERN, replaceTag);
-
-  return {
-    sourceText: nextSourceText,
-    changed,
-  };
-};
 
 const normalizeAnnotation = (annotation) => {
   if (!annotation || typeof annotation !== "object") {

--- a/src/lib/tutorial-shots-types.ts
+++ b/src/lib/tutorial-shots-types.ts
@@ -21,9 +21,7 @@ export type TutorialShotArrowAnnotation = {
 
 export type TutorialShotAnnotationMode = "focal" | "multi-focal" | "callout";
 
-export type TutorialShotAnnotation =
-  | TutorialShotBoxAnnotation
-  | TutorialShotArrowAnnotation;
+export type TutorialShotAnnotation = TutorialShotBoxAnnotation | TutorialShotArrowAnnotation;
 
 export type TutorialShotCrop = {
   x: number;
@@ -48,10 +46,21 @@ export type TutorialShotManifest = {
 /** Which MDX component this shot image is referenced from. */
 export type TutorialShotSource = "action" | "verify";
 
-export type TutorialShotItem = {
+export type TutorialShotSourceRef = {
+  pagePath: string;
+  tagName: "Action" | "Verify";
+  tagStart: number;
+  tagEnd: number;
+  imgValueStart: number;
+  imgValueEnd: number;
+  expectedImg: string;
+  pageRevision: string;
+  referenceKey: string;
+};
+
+export type TutorialShotItem = TutorialShotSourceRef & {
   id: string;
   line: number;
-  pagePath: string;
   sourceImagePath: string;
   referencedImagePath: string;
   outputImagePath: string;

--- a/tests/tutorial-shot-editor-flow.test.mjs
+++ b/tests/tutorial-shot-editor-flow.test.mjs
@@ -55,7 +55,9 @@ const waitFor = async (fn, { timeoutMs, intervalMs, onTimeoutMessage }) => {
   while (true) {
     if (Date.now() - startedAt > timeoutMs) {
       throw new Error(
-        typeof onTimeoutMessage === "function" ? onTimeoutMessage() : (onTimeoutMessage ?? "Timed out"),
+        typeof onTimeoutMessage === "function"
+          ? onTimeoutMessage()
+          : (onTimeoutMessage ?? "Timed out"),
       );
     }
     const result = await fn();
@@ -68,7 +70,10 @@ const waitFor = async (fn, { timeoutMs, intervalMs, onTimeoutMessage }) => {
 
 const tryFetchStatus = async (url, { timeoutMs = 10_000 } = {}) => {
   try {
-    const response = await fetch(url, { redirect: "manual", signal: AbortSignal.timeout(timeoutMs) });
+    const response = await fetch(url, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
     return response.status;
   } catch {
     return null;
@@ -760,6 +765,226 @@ test(
 );
 
 test(
+  "tutorial shot editor keeps shared image references independently selectable and saves only one",
+  { timeout: 3 * 60_000 },
+  async (t) => {
+    const tempRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "course-tutorial-shot-editor-shared-"),
+    );
+    const fixtureCourse = path.join(tempRoot, "course");
+    const overrideCourse = path.join(tempRoot, "override-course");
+    const port = await getFreePort();
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    await writeFixtureCourseRepo(fixtureCourse);
+    await writeFixtureCourseRepo(overrideCourse, {
+      logoText: "Shared Tutorial Shot Fixture",
+      firstImageName: "shared",
+      secondImageName: "unused",
+    });
+    const tutorialPagePath = path.join(overrideCourse, "content", "docs", "tutorial", "index.mdx");
+    await fs.writeFile(
+      tutorialPagePath,
+      `---
+title: Tutorial
+---
+
+<Section title="Step 1" goal="同じ画像の参照箇所を選ぶ">
+  <Action img="./img/shared.webp" alt="action source">
+    Action 側を編集します。
+  </Action>
+  <Verify img="./img/shared.webp">Verify 側を確認します。</Verify>
+</Section>
+`,
+      "utf8",
+    );
+    const overrideCourseRelativePath = path.relative(projectRoot, overrideCourse);
+    const dev = spawn(process.execPath, ["scripts/run-dev.mjs", "--port", String(port)], {
+      detached: process.platform !== "win32",
+      windowsHide: true,
+      cwd: projectRoot,
+      env: createRunDevTestEnv({
+        label: "tutorial-shot-editor-shared-reference",
+        env: process.env,
+        overrides: {
+          COURSE_CONTENT_SOURCE: fixtureCourse,
+        },
+      }),
+      stdio: "inherit",
+    });
+
+    t.after(async () => {
+      await killProcessTreeAndWaitForPort(dev, port);
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    });
+    await waitFor(
+      async () => {
+        const status = await tryFetchStatus(`${baseUrl}/dev/tutorial-shots/`);
+        return status === 200 || status === 308;
+      },
+      {
+        timeoutMs: 120_000,
+        intervalMs: 1000,
+        onTimeoutMessage: "Tutorial shot editor did not become ready for shared references.",
+      },
+    );
+
+    let browser;
+    t.after(async () => {
+      await closeBrowserBounded(browser);
+    });
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({
+      baseURL: baseUrl,
+      viewport: { width: 1440, height: 1100 },
+    });
+    const duplicateKeyMessages = [];
+    page.on("console", (message) => {
+      if (message.text().includes("Encountered two children with the same key")) {
+        duplicateKeyMessages.push(message.text());
+      }
+    });
+
+    await openTutorialShotEditor(page, overrideCourseRelativePath, {
+      firstShotButtonName: /shared.*Action.*6 行目/iu,
+    });
+    const sidebar = page.locator('aside[aria-label="編集する画像の一覧"]');
+    await assert.equal(await sidebar.getByRole("button").count(), 2);
+
+    const verifyButton = sidebar.getByRole("button", { name: /shared.*Verify.*9 行目/iu });
+    await verifyButton.click();
+    const workspace = page.locator('section[aria-label="画像エディタ"]');
+    await workspace.getByText("Verify", { exact: true }).waitFor();
+    await workspace.getByText("9 行目", { exact: true }).waitFor();
+
+    await page.keyboard.press("Shift+Tab");
+    const focusedShotState = await page.evaluate(() => {
+      const active = document.activeElement;
+      if (!(active instanceof HTMLButtonElement)) {
+        return null;
+      }
+      const style = getComputedStyle(active);
+      return {
+        outlineStyle: style.outlineStyle,
+        outlineWidth: style.outlineWidth,
+        text: active.textContent,
+      };
+    });
+    assert.match(focusedShotState?.text ?? "", /shared.*Action.*6 行目/isu);
+    assert.notEqual(focusedShotState?.outlineStyle, "none");
+    assert.notEqual(focusedShotState?.outlineWidth, "0px");
+    await page.keyboard.press("Enter");
+    await workspace.getByText("Action", { exact: true }).waitFor();
+    await workspace.getByText("6 行目", { exact: true }).waitFor();
+
+    await page.setViewportSize({ width: 760, height: 1000 });
+    const reducedWidthLayout = await page.evaluate(() => {
+      const documentElement = document.documentElement;
+      const sidebarElement = document.querySelector('aside[aria-label="編集する画像の一覧"]');
+      const shotButtons = Array.from(sidebarElement?.querySelectorAll("button") ?? []);
+      return {
+        hasDocumentOverflow: documentElement.scrollWidth > documentElement.clientWidth,
+        sidebarWithinViewport:
+          sidebarElement instanceof HTMLElement &&
+          sidebarElement.getBoundingClientRect().right <= documentElement.clientWidth,
+        shotButtonsWithinViewport: shotButtons.every(
+          (button) => button.getBoundingClientRect().right <= documentElement.clientWidth,
+        ),
+      };
+    });
+    assert.deepEqual(reducedWidthLayout, {
+      hasDocumentOverflow: false,
+      sidebarWithinViewport: true,
+      shotButtonsWithinViewport: true,
+    });
+    await page.setViewportSize({ width: 1440, height: 1100 });
+
+    await page.getByLabel("画像の説明（Alt テキスト）").fill("Action だけの説明");
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await page.getByText("保存しました").waitFor();
+
+    await sidebar.getByRole("button", { name: /shared.*Verify.*9 行目/iu }).click();
+    await waitFor(
+      async () => (await page.getByLabel("画像の説明（Alt テキスト）").inputValue()) === "",
+      {
+        timeoutMs: 10_000,
+        intervalMs: 100,
+        onTimeoutMessage: "The Verify reference did not become the selected edit state.",
+      },
+    );
+    await assert.equal(await page.getByLabel("画像の説明（Alt テキスト）").inputValue(), "");
+    const branchedActionButton = sidebar.getByRole("button", {
+      name: /shared-[a-f0-9]{6}.*Action.*6 行目/iu,
+    });
+    await branchedActionButton.click();
+    await waitFor(
+      async () =>
+        (await page.getByLabel("画像の説明（Alt テキスト）").inputValue()) === "Action だけの説明",
+      {
+        timeoutMs: 10_000,
+        intervalMs: 100,
+        onTimeoutMessage: "The branched Action manifest did not become the selected edit state.",
+      },
+    );
+    await assert.equal(
+      await page.getByLabel("画像の説明（Alt テキスト）").inputValue(),
+      "Action だけの説明",
+    );
+
+    const savedPageSource = await fs.readFile(tutorialPagePath, "utf8");
+    assert.match(
+      savedPageSource,
+      /<Action img="\.\/img\/shared--[a-f0-9]{6}\.webp" alt="action source">/u,
+    );
+    assert.match(
+      savedPageSource,
+      /<Verify img="\.\/img\/shared\.webp">Verify 側を確認します。<\/Verify>/u,
+    );
+    const imageFiles = await fs.readdir(
+      path.join(overrideCourse, "content", "docs", "tutorial", "img"),
+    );
+    const shotFiles = await fs.readdir(
+      path.join(overrideCourse, "content", "docs", "tutorial", "shots"),
+    );
+    const branchedImageFile = imageFiles.find((fileName) =>
+      /^shared--[a-f0-9]{6}\.webp$/u.test(fileName),
+    );
+    const branchedRawFile = shotFiles.find((fileName) =>
+      /^shared--[a-f0-9]{6}\.raw\.webp$/u.test(fileName),
+    );
+    const branchedManifestFile = shotFiles.find((fileName) =>
+      /^shared--[a-f0-9]{6}\.shot\.json$/u.test(fileName),
+    );
+    assert.equal(typeof branchedImageFile, "string");
+    assert.equal(typeof branchedRawFile, "string");
+    assert.equal(typeof branchedManifestFile, "string");
+
+    await fs.appendFile(tutorialPagePath, "\n{/* changed after the editor scan */}\n", "utf8");
+    const conflictArtifactPaths = [
+      tutorialPagePath,
+      path.join(overrideCourse, "content", "docs", "tutorial", "img", branchedImageFile),
+      path.join(overrideCourse, "content", "docs", "tutorial", "shots", branchedRawFile),
+      path.join(overrideCourse, "content", "docs", "tutorial", "shots", branchedManifestFile),
+    ];
+    const conflictArtifactsBefore = await Promise.all(
+      conflictArtifactPaths.map((artifactPath) => fs.readFile(artifactPath)),
+    );
+    await page.getByLabel("画像の説明（Alt テキスト）").fill("競合時には保存されない説明");
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await page
+      .getByText("教材が更新されています。一覧を再読み込みしてから、もう一度保存してください。", {
+        exact: true,
+      })
+      .waitFor();
+    const conflictArtifactsAfter = await Promise.all(
+      conflictArtifactPaths.map((artifactPath) => fs.readFile(artifactPath)),
+    );
+    assert.deepEqual(conflictArtifactsAfter, conflictArtifactsBefore);
+    assert.deepEqual(duplicateKeyMessages, []);
+  },
+);
+
+test(
   "tutorial shot editor can edit an Action image whose filename contains spaces",
   { timeout: 3 * 60_000 },
   async (t) => {
@@ -1193,7 +1418,14 @@ test(
     await syncContentForDevTest(devEnv);
     await assert.doesNotReject(() =>
       fs.stat(
-        path.join(projectRoot, "content", "docs", "tutorial", "img", `${liveRefreshImageName}.webp`),
+        path.join(
+          projectRoot,
+          "content",
+          "docs",
+          "tutorial",
+          "img",
+          `${liveRefreshImageName}.webp`,
+        ),
       ),
     );
 
@@ -1201,11 +1433,11 @@ test(
       process.execPath,
       [path.join(projectRoot, "scripts", "run-dev.mjs"), "--port", String(port)],
       {
-      detached: process.platform !== "win32",
-      windowsHide: true,
-      cwd: projectRoot,
-      env: devEnv,
-      stdio: "inherit",
+        detached: process.platform !== "win32",
+        windowsHide: true,
+        cwd: projectRoot,
+        env: devEnv,
+        stdio: "inherit",
       },
     );
 
@@ -1244,7 +1476,8 @@ test(
       expectedSourcePath: fixtureCourse,
       expectedShotId: liveRefreshImageName,
       expectedOutputImagePath: liveRefreshOutputImagePath,
-      onTimeoutMessage: "Tutorial shot editor API did not expose the exact live-refresh fixture image.",
+      onTimeoutMessage:
+        "Tutorial shot editor API did not expose the exact live-refresh fixture image.",
     });
 
     let browser;
@@ -1562,15 +1795,12 @@ title: Tutorial
       },
     );
 
-    await waitForTutorialShotsApiReady(
-      baseUrl,
-      {
-        expectedSourcePath: fixtureCourse,
-        expectedShotId: verifyImageName,
-        expectedOutputImagePath: verifyOutputImagePath,
-        onTimeoutMessage: "Tutorial shot editor API did not stay ready for Verify image save.",
-      },
-    );
+    await waitForTutorialShotsApiReady(baseUrl, {
+      expectedSourcePath: fixtureCourse,
+      expectedShotId: verifyImageName,
+      expectedOutputImagePath: verifyOutputImagePath,
+      onTimeoutMessage: "Tutorial shot editor API did not stay ready for Verify image save.",
+    });
 
     await editorPage.goto("/dev/tutorial-shots/", { waitUntil: "domcontentloaded" });
     await editorPage.getByRole("heading", { name: "チュートリアル画像エディタ" }).waitFor();
@@ -1614,10 +1844,12 @@ title: Tutorial
       async () => {
         try {
           return (
-            await evaluateExactTutorialImage(previewPage, verifyProbeImageDescriptor, {
-              scanForAnnotationStroke: true,
-            })
-          ).hasAnnotationStrokePixel === true;
+            (
+              await evaluateExactTutorialImage(previewPage, verifyProbeImageDescriptor, {
+                scanForAnnotationStroke: true,
+              })
+            ).hasAnnotationStrokePixel === true
+          );
         } catch {
           return false;
         }
@@ -2049,14 +2281,11 @@ test(
       await fs.rm(tempRoot, { recursive: true, force: true });
     });
 
-    const readyResult = await waitForTutorialShotsApiReady(
-      baseUrl,
-      {
-        expectedSourcePath: fixtureCourseEnvPath,
-        expectedShotId: "startup",
-        onTimeoutMessage: "Tutorial shot editor API did not become ready from env file startup.",
-      },
-    );
+    const readyResult = await waitForTutorialShotsApiReady(baseUrl, {
+      expectedSourcePath: fixtureCourseEnvPath,
+      expectedShotId: "startup",
+      onTimeoutMessage: "Tutorial shot editor API did not become ready from env file startup.",
+    });
 
     const { status, data } = readyResult;
 

--- a/tests/tutorial-shots.test.mjs
+++ b/tests/tutorial-shots.test.mjs
@@ -30,7 +30,7 @@ import {
 import {
   getTutorialShotAuthoringContext,
   readTutorialShotImage,
-  saveTutorialShot,
+  saveTutorialShot as saveTutorialShotImpl,
   scanTutorialShots,
 } from "../src/lib/tutorial-shots-server.mjs";
 
@@ -71,6 +71,107 @@ title: Student Guide
   } else {
     await fixtureImage.png().toFile(imagePath);
   }
+};
+
+const toTutorialShotSourceRef = (shot) => ({
+  pagePath: shot.pagePath,
+  tagName: shot.tagName,
+  tagStart: shot.tagStart,
+  tagEnd: shot.tagEnd,
+  imgValueStart: shot.imgValueStart,
+  imgValueEnd: shot.imgValueEnd,
+  expectedImg: shot.expectedImg,
+  pageRevision: shot.pageRevision,
+  referenceKey: shot.referenceKey,
+});
+
+const getOnlyTutorialShotSourceRef = async (sourceRoot) => {
+  const shots = await scanTutorialShots({ sourceRoot });
+  assert.equal(shots.length, 1, "the fixture must contain exactly one tutorial shot reference");
+  return toTutorialShotSourceRef(shots[0]);
+};
+
+const saveTutorialShot = async (options) =>
+  saveTutorialShotImpl({
+    ...options,
+    sourceRef: options.sourceRef ?? (await getOnlyTutorialShotSourceRef(options.sourceRoot)),
+  });
+
+const writeDuplicateTutorialShotFixture = async (
+  rootDir,
+  { sameTagName = false, crossPage = false, withGeneratedFiles = false } = {},
+) => {
+  const pageDir = path.join(rootDir, "content", "docs", "student-guide");
+  const imageDir = path.join(pageDir, "img");
+  const shotsDir = path.join(pageDir, "shots");
+  await fs.mkdir(imageDir, { recursive: true });
+
+  const secondReference = sameTagName
+    ? '<Action img="./img/compile-success.png">もう一度コンパイルします。</Action>'
+    : '<Verify img="./img/compile-success.png">成功したことを確認します。</Verify>';
+  await fs.writeFile(
+    path.join(pageDir, "index.mdx"),
+    `---
+title: Student Guide
+---
+
+<Section title="Step 1" goal="コンパイル結果を確認する">
+  <Action img="./img/compile-success.png" alt="compile result">
+    コンパイルして、保存します。
+  </Action>
+  ${secondReference}
+</Section>
+`,
+    "utf8",
+  );
+
+  const sourceImage = sharp({
+    create: {
+      width: 640,
+      height: 360,
+      channels: 4,
+      background: "#dbe4f0",
+    },
+  });
+  await sourceImage.png().toFile(path.join(imageDir, "compile-success.png"));
+
+  if (crossPage) {
+    const otherPageDir = path.join(rootDir, "content", "docs", "other-page");
+    await fs.mkdir(otherPageDir, { recursive: true });
+    await fs.writeFile(
+      path.join(otherPageDir, "index.mdx"),
+      `---
+title: Other Page
+---
+
+<Section title="Step 2" goal="同じ結果を確認する">
+  <Verify img="../student-guide/img/compile-success.png">同じ画像を確認します。</Verify>
+</Section>
+`,
+      "utf8",
+    );
+  }
+
+  if (!withGeneratedFiles) {
+    return;
+  }
+
+  await fs.mkdir(shotsDir, { recursive: true });
+  await sourceImage.webp({ lossless: true }).toFile(path.join(imageDir, "compile-success.webp"));
+  await sourceImage.png().toFile(path.join(shotsDir, "compile-success.raw.png"));
+  const manifest = {
+    ...createDefaultTutorialShotManifest({
+      pagePath: "content/docs/student-guide/index.mdx",
+      outputImagePath: "content/docs/student-guide/img/compile-success.webp",
+    }),
+    rawImagePath: "content/docs/student-guide/shots/compile-success.raw.png",
+    alt: "保存前の画像",
+  };
+  await fs.writeFile(
+    path.join(shotsDir, "compile-success.shot.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
 };
 
 const toDataUrl = (buffer, mimeType = "image/png") =>
@@ -305,11 +406,13 @@ test("saveTutorialShot rejects non-image raw uploads before writing raw files", 
     "shots",
     "startup.raw.png",
   );
+  const sourceRef = await getOnlyTutorialShotSourceRef(sourceRoot);
 
   await assert.rejects(
     () =>
       saveTutorialShot({
         sourceRoot,
+        sourceRef,
         manifestInput: manifest,
         rawImageDataUrl: toDataUrl(Buffer.from("not an image"), "text/plain"),
       }),
@@ -347,6 +450,7 @@ test("saveTutorialShot preserves raw PNG uploads and generates cropped annotated
 
   await saveTutorialShot({
     sourceRoot,
+    sourceRef: await getOnlyTutorialShotSourceRef(sourceRoot),
     manifestInput: {
       ...manifest,
       crop: {
@@ -458,6 +562,7 @@ test("saveTutorialShot preserves animated WebP uploads as cropped annotated anim
 
   await saveTutorialShot({
     sourceRoot,
+    sourceRef: await getOnlyTutorialShotSourceRef(sourceRoot),
     manifestInput: {
       ...manifest,
       crop: {
@@ -582,11 +687,13 @@ test("saveTutorialShot rejects MIME-spoofed unsupported raw uploads", async (t) 
     "shots",
     "startup.raw.png",
   );
+  const sourceRef = await getOnlyTutorialShotSourceRef(sourceRoot);
 
   await assert.rejects(
     () =>
       saveTutorialShot({
         sourceRoot,
+        sourceRef,
         manifestInput: manifest,
         rawImageDataUrl: toDataUrl(tiffImageBuffer, "image/png"),
       }),
@@ -811,6 +918,292 @@ title: Student Guide
   } finally {
     await fs.rm(rootDir, { recursive: true, force: true });
   }
+});
+
+test("scanTutorialShots returns distinct source references for Action and Verify tags sharing one image", async (t) => {
+  const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "duplicate-shot-scan-"));
+  t.after(async () => {
+    await fs.rm(sourceRoot, { recursive: true, force: true });
+  });
+  await writeDuplicateTutorialShotFixture(sourceRoot);
+
+  const shots = await scanTutorialShots({ sourceRoot });
+  const pageSource = await fs.readFile(
+    path.join(sourceRoot, "content", "docs", "student-guide", "index.mdx"),
+    "utf8",
+  );
+
+  assert.equal(shots.length, 2);
+  assert.equal(shots[0].outputImagePath, shots[1].outputImagePath);
+  assert.equal(shots[0].bootstrapImagePath, shots[1].bootstrapImagePath);
+  assert.notEqual(shots[0].referenceKey, shots[1].referenceKey);
+  assert.deepEqual(
+    shots.map((shot) => shot.tagName),
+    ["Action", "Verify"],
+  );
+  for (const shot of shots) {
+    assert.match(shot.pageRevision, /^[a-f0-9]{64}$/u);
+    assert.match(shot.referenceKey, /^[a-f0-9]{64}$/u);
+    assert.equal(shot.expectedImg, "./img/compile-success.png");
+    assert.equal(
+      pageSource.slice(shot.imgValueStart, shot.imgValueEnd),
+      "./img/compile-success.png",
+    );
+    assert.match(
+      pageSource.slice(shot.tagStart, shot.tagEnd),
+      new RegExp(`^<${shot.tagName}\\b`, "u"),
+    );
+    assert.equal("occurrence" in shot, false);
+  }
+});
+
+test("scanTutorialShots returns distinct source references for repeated tags of the same kind", async (t) => {
+  const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "duplicate-action-shot-scan-"));
+  t.after(async () => {
+    await fs.rm(sourceRoot, { recursive: true, force: true });
+  });
+  await writeDuplicateTutorialShotFixture(sourceRoot, { sameTagName: true });
+
+  const shots = await scanTutorialShots({ sourceRoot });
+
+  assert.equal(shots.length, 2);
+  assert.deepEqual(
+    shots.map((shot) => shot.tagName),
+    ["Action", "Action"],
+  );
+  assert.notEqual(shots[0].referenceKey, shots[1].referenceKey);
+  assert.equal(
+    shots.some((shot) => "occurrence" in shot),
+    false,
+  );
+});
+
+test("scanTutorialShots distinguishes references to one image from different pages", async (t) => {
+  const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cross-page-shot-scan-"));
+  t.after(async () => {
+    await fs.rm(sourceRoot, { recursive: true, force: true });
+  });
+  await writeDuplicateTutorialShotFixture(sourceRoot, { crossPage: true });
+
+  const shots = await scanTutorialShots({ sourceRoot });
+  const sharedImageShots = shots.filter(
+    (shot) => shot.referencedImagePath === "content/docs/student-guide/img/compile-success.png",
+  );
+
+  assert.equal(sharedImageShots.length, 3);
+  assert.equal(new Set(sharedImageShots.map((shot) => shot.referenceKey)).size, 3);
+  assert.equal(new Set(sharedImageShots.map((shot) => shot.pagePath)).size, 2);
+});
+
+test("saveTutorialShot branches only the selected source reference when an image is shared", async (t) => {
+  const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "duplicate-shot-save-"));
+  t.after(async () => {
+    await fs.rm(sourceRoot, { recursive: true, force: true });
+  });
+  await writeDuplicateTutorialShotFixture(sourceRoot, { withGeneratedFiles: true });
+
+  const originalOutputPath = path.join(
+    sourceRoot,
+    "content",
+    "docs",
+    "student-guide",
+    "img",
+    "compile-success.webp",
+  );
+  const originalRawPath = path.join(
+    sourceRoot,
+    "content",
+    "docs",
+    "student-guide",
+    "shots",
+    "compile-success.raw.png",
+  );
+  const originalManifestPath = path.join(
+    sourceRoot,
+    "content",
+    "docs",
+    "student-guide",
+    "shots",
+    "compile-success.shot.json",
+  );
+  const [originalOutput, originalRaw, originalManifest] = await Promise.all([
+    fs.readFile(originalOutputPath),
+    fs.readFile(originalRawPath),
+    fs.readFile(originalManifestPath),
+  ]);
+  const initialShots = await scanTutorialShots({ sourceRoot });
+  const actionShot = initialShots.find((shot) => shot.tagName === "Action");
+  assert.ok(actionShot);
+
+  const result = await saveTutorialShot({
+    sourceRoot,
+    sourceRef: toTutorialShotSourceRef(actionShot),
+    manifestInput: {
+      ...actionShot.manifest,
+      alt: "分岐した Action 画像",
+    },
+  });
+
+  assert.match(
+    result.manifest.outputImagePath,
+    /^content\/docs\/student-guide\/img\/compile-success--[a-f0-9]{6}\.webp$/u,
+  );
+  assert.match(
+    result.manifest.rawImagePath,
+    /^content\/docs\/student-guide\/shots\/compile-success--[a-f0-9]{6}\.raw\.png$/u,
+  );
+  assert.match(result.manifest.id, /^compile-success-[a-f0-9]{6}$/u);
+
+  const savedPageSource = await fs.readFile(
+    path.join(sourceRoot, "content", "docs", "student-guide", "index.mdx"),
+    "utf8",
+  );
+  assert.match(
+    savedPageSource,
+    /<Action img="\.\/img\/compile-success--[a-f0-9]{6}\.webp" alt="compile result">/u,
+  );
+  assert.match(
+    savedPageSource,
+    /<Verify img="\.\/img\/compile-success\.png">成功したことを確認します。<\/Verify>/u,
+  );
+
+  const branchedOutputPath = path.join(sourceRoot, result.manifest.outputImagePath);
+  const branchedRawPath = path.join(sourceRoot, result.manifest.rawImagePath);
+  const branchedManifestPath = path.join(
+    sourceRoot,
+    "content",
+    "docs",
+    "student-guide",
+    "shots",
+    `${path.basename(result.manifest.outputImagePath, ".webp")}.shot.json`,
+  );
+  await Promise.all([
+    fs.stat(branchedOutputPath),
+    fs.stat(branchedRawPath),
+    fs.stat(branchedManifestPath),
+  ]);
+  assert.deepEqual(await fs.readFile(originalOutputPath), originalOutput);
+  assert.deepEqual(await fs.readFile(originalRawPath), originalRaw);
+  assert.deepEqual(await fs.readFile(originalManifestPath), originalManifest);
+
+  const rescannedShots = await scanTutorialShots({ sourceRoot });
+  assert.equal(rescannedShots.length, 2);
+  assert.equal(
+    rescannedShots.some((shot) => shot.referenceKey === actionShot.referenceKey),
+    false,
+  );
+  assert.equal(new Set(rescannedShots.map((shot) => shot.outputImagePath)).size, 2);
+  assert.equal(result.sourceRef.referenceKey, rescannedShots[0].referenceKey);
+});
+
+test("saveTutorialShot reuses a branched path and its raw image on later edits", async (t) => {
+  const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "branched-shot-resave-"));
+  t.after(async () => {
+    await fs.rm(sourceRoot, { recursive: true, force: true });
+  });
+  await writeDuplicateTutorialShotFixture(sourceRoot, { withGeneratedFiles: true });
+
+  const initialShots = await scanTutorialShots({ sourceRoot });
+  const actionShot = initialShots.find((shot) => shot.tagName === "Action");
+  assert.ok(actionShot);
+  const firstSave = await saveTutorialShot({
+    sourceRoot,
+    sourceRef: toTutorialShotSourceRef(actionShot),
+    manifestInput: {
+      ...actionShot.manifest,
+      alt: "最初の分岐保存",
+    },
+  });
+  const branchedOutputPath = path.join(sourceRoot, firstSave.manifest.outputImagePath);
+  const firstGeneratedOutput = await fs.readFile(branchedOutputPath);
+
+  await sharp({
+    create: { width: 640, height: 360, channels: 4, background: "#ef4444" },
+  })
+    .webp({ lossless: true })
+    .toFile(branchedOutputPath);
+
+  const rescannedShots = await scanTutorialShots({ sourceRoot });
+  const branchedShot = rescannedShots.find(
+    (shot) => shot.outputImagePath === firstSave.manifest.outputImagePath,
+  );
+  assert.ok(branchedShot);
+  const secondSave = await saveTutorialShot({
+    sourceRoot,
+    sourceRef: toTutorialShotSourceRef(branchedShot),
+    manifestInput: {
+      ...branchedShot.manifest,
+      alt: "再編集した分岐画像",
+    },
+  });
+
+  assert.equal(secondSave.manifest.outputImagePath, firstSave.manifest.outputImagePath);
+  assert.equal(secondSave.manifest.rawImagePath, firstSave.manifest.rawImagePath);
+  assert.deepEqual(await fs.readFile(branchedOutputPath), firstGeneratedOutput);
+  assert.doesNotMatch(secondSave.manifest.outputImagePath, /--[a-f0-9]{6}--/u);
+
+  const imageFiles = await fs.readdir(
+    path.join(sourceRoot, "content", "docs", "student-guide", "img"),
+  );
+  const shotFiles = await fs.readdir(
+    path.join(sourceRoot, "content", "docs", "student-guide", "shots"),
+  );
+  assert.equal(
+    imageFiles.filter((fileName) => /^compile-success--[a-f0-9]{6}\.webp$/u.test(fileName)).length,
+    1,
+  );
+  assert.equal(
+    shotFiles.filter((fileName) => /^compile-success--[a-f0-9]{6}\.shot\.json$/u.test(fileName))
+      .length,
+    1,
+  );
+  assert.equal(
+    shotFiles.filter((fileName) => /^compile-success--[a-f0-9]{6}\.raw\.png$/u.test(fileName))
+      .length,
+    1,
+  );
+});
+
+test("saveTutorialShot rejects a stale source reference before changing any artifact", async (t) => {
+  const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "stale-shot-save-"));
+  t.after(async () => {
+    await fs.rm(sourceRoot, { recursive: true, force: true });
+  });
+  await writeDuplicateTutorialShotFixture(sourceRoot, { withGeneratedFiles: true });
+
+  const initialShots = await scanTutorialShots({ sourceRoot });
+  const actionShot = initialShots.find((shot) => shot.tagName === "Action");
+  assert.ok(actionShot);
+  const pagePath = path.join(sourceRoot, actionShot.pagePath);
+  await fs.appendFile(pagePath, "\n{/* changed after scanning */}\n", "utf8");
+
+  const artifactPaths = [
+    pagePath,
+    path.join(sourceRoot, actionShot.outputImagePath),
+    path.join(sourceRoot, actionShot.rawImagePath),
+    path.join(sourceRoot, actionShot.manifestPath),
+  ];
+  const before = await Promise.all(artifactPaths.map((artifactPath) => fs.readFile(artifactPath)));
+
+  await assert.rejects(
+    () =>
+      saveTutorialShot({
+        sourceRoot,
+        sourceRef: toTutorialShotSourceRef(actionShot),
+        manifestInput: {
+          ...actionShot.manifest,
+          alt: "この変更は保存されない",
+        },
+      }),
+    (error) => {
+      assert.equal(error?.statusCode, 409);
+      assert.match(error?.message ?? "", /教材が更新されています/u);
+      return true;
+    },
+  );
+
+  const after = await Promise.all(artifactPaths.map((artifactPath) => fs.readFile(artifactPath)));
+  assert.deepEqual(after, before);
 });
 
 test("getTutorialShotWarnings validates focal mode annotations", () => {
@@ -1877,7 +2270,10 @@ test("saveTutorialShot keeps reporting a missing raw image once annotations are 
     await fs.rm(sourceRoot, { recursive: true, force: true });
   });
 
-  await writeTutorialFixture(sourceRoot);
+  await writeTutorialFixture(sourceRoot, {
+    actionImageSrc: "./img/missing.png",
+    imageFileName: "startup.png",
+  });
 
   const manifest = createDefaultTutorialShotManifest({
     pagePath: "content/docs/student-guide/index.mdx",

--- a/tests/tutorial-shots.test.mjs
+++ b/tests/tutorial-shots.test.mjs
@@ -28,10 +28,13 @@ import {
   updateTutorialShotCropStateMap,
 } from "../src/lib/tutorial-shot-editor-crop-state.mjs";
 import {
+  commitTutorialShotFiles,
+  getTutorialShotArtifactIdentity,
   getTutorialShotAuthoringContext,
   readTutorialShotImage,
   saveTutorialShot as saveTutorialShotImpl,
   scanTutorialShots,
+  tutorialShotRefsShareArtifacts,
 } from "../src/lib/tutorial-shots-server.mjs";
 
 const writeTutorialFixture = async (
@@ -172,6 +175,75 @@ title: Other Page
     `${JSON.stringify(manifest, null, 2)}\n`,
     "utf8",
   );
+};
+
+const writeArtifactCollisionFixture = async (rootDir, { kind }) => {
+  const pageDir = path.join(rootDir, "content", "docs", "student-guide");
+  const imageDir = path.join(pageDir, "img");
+  const screensDir = path.join(pageDir, "screens");
+  const shotsDir = path.join(pageDir, "shots");
+  await Promise.all([
+    fs.mkdir(imageDir, { recursive: true }),
+    fs.mkdir(screensDir, { recursive: true }),
+    fs.mkdir(shotsDir, { recursive: true }),
+  ]);
+
+  const isOutputPolicyCollision = kind === "output-policy";
+  const actionSrc = "./img/result.png";
+  const verifySrc = isOutputPolicyCollision ? "./img/result.webp" : "./screens/result.png";
+  await fs.writeFile(
+    path.join(pageDir, "index.mdx"),
+    `---
+title: Student Guide
+---
+
+<Section title="Step 1" goal="結果を確認する">
+  <Action img="${actionSrc}">操作結果を保存します。</Action>
+  <Verify img="${verifySrc}">保存結果を確認します。</Verify>
+</Section>
+`,
+    "utf8",
+  );
+
+  const makeImage = (background) =>
+    sharp({
+      create: { width: 64, height: 48, channels: 4, background },
+    });
+  await makeImage("#2563eb").png().toFile(path.join(imageDir, "result.png"));
+  await makeImage("#16a34a").webp({ lossless: true }).toFile(path.join(imageDir, "result.webp"));
+
+  if (!isOutputPolicyCollision) {
+    await makeImage("#9333ea").png().toFile(path.join(screensDir, "result.png"));
+    await makeImage("#ea580c")
+      .webp({ lossless: true })
+      .toFile(path.join(screensDir, "result.webp"));
+  }
+
+  const rawExtension = isOutputPolicyCollision ? ".webp" : ".png";
+  const rawPath = path.join(shotsDir, `result.raw${rawExtension}`);
+  if (isOutputPolicyCollision) {
+    await makeImage("#dc2626").webp({ lossless: true }).toFile(rawPath);
+  } else {
+    await makeImage("#dc2626").png().toFile(rawPath);
+  }
+  const manifest = {
+    ...createDefaultTutorialShotManifest({
+      pagePath: "content/docs/student-guide/index.mdx",
+      outputImagePath: "content/docs/student-guide/img/result.webp",
+    }),
+    rawImagePath: `content/docs/student-guide/shots/result.raw${rawExtension}`,
+    alt: "保存前の生成物",
+  };
+  const manifestPath = path.join(shotsDir, "result.shot.json");
+  await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  return {
+    imageDir,
+    manifestPath,
+    pagePath: path.join(pageDir, "index.mdx"),
+    rawPath,
+    screensDir,
+  };
 };
 
 const toDataUrl = (buffer, mimeType = "image/png") =>
@@ -1094,6 +1166,366 @@ test("saveTutorialShot branches only the selected source reference when an image
   );
   assert.equal(new Set(rescannedShots.map((shot) => shot.outputImagePath)).size, 2);
   assert.equal(result.sourceRef.referenceKey, rescannedShots[0].referenceKey);
+});
+
+test("saveTutorialShot branches when PNG and WebP references converge on the same generated artifacts", async (t) => {
+  const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "output-policy-collision-"));
+  t.after(async () => {
+    await fs.rm(sourceRoot, { recursive: true, force: true });
+  });
+  const fixture = await writeArtifactCollisionFixture(sourceRoot, { kind: "output-policy" });
+  const originalPaths = [
+    path.join(fixture.imageDir, "result.webp"),
+    fixture.rawPath,
+    fixture.manifestPath,
+  ];
+  const originalArtifacts = await Promise.all(
+    originalPaths.map((artifactPath) => fs.readFile(artifactPath)),
+  );
+  const shots = await scanTutorialShots({ sourceRoot });
+  const actionShot = shots.find((shot) => shot.tagName === "Action");
+  assert.ok(actionShot);
+
+  const result = await saveTutorialShot({
+    sourceRoot,
+    sourceRef: toTutorialShotSourceRef(actionShot),
+    manifestInput: { ...actionShot.manifest, alt: "分岐した PNG 参照" },
+  });
+
+  assert.match(
+    result.manifest.outputImagePath,
+    /^content\/docs\/student-guide\/img\/result--[a-f0-9]{6}\.webp$/u,
+  );
+  assert.match(
+    result.manifest.rawImagePath,
+    /^content\/docs\/student-guide\/shots\/result--[a-f0-9]{6}\.raw\.webp$/u,
+  );
+  const savedPage = await fs.readFile(fixture.pagePath, "utf8");
+  assert.match(savedPage, /<Action img="\.\/img\/result--[a-f0-9]{6}\.webp">/u);
+  assert.match(savedPage, /<Verify img="\.\/img\/result\.webp">/u);
+  const currentArtifacts = await Promise.all(
+    originalPaths.map((artifactPath) => fs.readFile(artifactPath)),
+  );
+  assert.deepEqual(currentArtifacts, originalArtifacts);
+});
+
+test("saveTutorialShot branches when different image directories share manifest and raw artifacts", async (t) => {
+  const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "same-stem-collision-"));
+  t.after(async () => {
+    await fs.rm(sourceRoot, { recursive: true, force: true });
+  });
+  const fixture = await writeArtifactCollisionFixture(sourceRoot, { kind: "directories" });
+  const originalPaths = [
+    path.join(fixture.imageDir, "result.webp"),
+    path.join(fixture.screensDir, "result.webp"),
+    fixture.rawPath,
+    fixture.manifestPath,
+  ];
+  const originalArtifacts = await Promise.all(
+    originalPaths.map((artifactPath) => fs.readFile(artifactPath)),
+  );
+  const shots = await scanTutorialShots({ sourceRoot });
+  const verifyShot = shots.find((shot) => shot.tagName === "Verify");
+  assert.ok(verifyShot);
+  assert.notEqual(shots[0].outputImagePath, shots[1].outputImagePath);
+  assert.equal(shots[0].manifestPath, shots[1].manifestPath);
+  assert.equal(shots[0].rawImagePath, shots[1].rawImagePath);
+
+  const result = await saveTutorialShot({
+    sourceRoot,
+    sourceRef: toTutorialShotSourceRef(verifyShot),
+    manifestInput: { ...verifyShot.manifest, alt: "分岐した別ディレクトリ参照" },
+  });
+
+  assert.match(
+    result.manifest.outputImagePath,
+    /^content\/docs\/student-guide\/screens\/result--[a-f0-9]{6}\.webp$/u,
+  );
+  assert.match(
+    result.manifest.rawImagePath,
+    /^content\/docs\/student-guide\/shots\/result--[a-f0-9]{6}\.raw\.png$/u,
+  );
+  const savedPage = await fs.readFile(fixture.pagePath, "utf8");
+  assert.match(savedPage, /<Action img="\.\/img\/result\.png">/u);
+  assert.match(savedPage, /<Verify img="\.\/screens\/result--[a-f0-9]{6}\.webp">/u);
+  const currentArtifacts = await Promise.all(
+    originalPaths.map((artifactPath) => fs.readFile(artifactPath)),
+  );
+  assert.deepEqual(currentArtifacts, originalArtifacts);
+});
+
+test("tutorial shot artifact identity is case-insensitive only for Windows semantics", () => {
+  const sourceRoot = path.resolve("artifact-identity-root");
+  const upperPath = "content/docs/Guide/img/Result.webp";
+  const lowerPath = "content/docs/guide/img/result.webp";
+
+  assert.equal(
+    getTutorialShotArtifactIdentity({
+      sourceRoot,
+      contentRelativePath: upperPath,
+      platform: "win32",
+    }),
+    getTutorialShotArtifactIdentity({
+      sourceRoot,
+      contentRelativePath: lowerPath,
+      platform: "win32",
+    }),
+  );
+  assert.notEqual(
+    getTutorialShotArtifactIdentity({
+      sourceRoot,
+      contentRelativePath: upperPath,
+      platform: "linux",
+    }),
+    getTutorialShotArtifactIdentity({
+      sourceRoot,
+      contentRelativePath: lowerPath,
+      platform: "linux",
+    }),
+  );
+
+  const upperRef = {
+    pagePath: "content/docs/Guide/index.mdx",
+    referencedImagePath: "content/docs/Guide/img/Result.png",
+  };
+  const lowerRef = {
+    pagePath: "content/docs/guide/index.mdx",
+    referencedImagePath: "content/docs/guide/img/result.png",
+  };
+  assert.equal(
+    tutorialShotRefsShareArtifacts({
+      sourceRoot,
+      left: upperRef,
+      right: lowerRef,
+      platform: "win32",
+    }),
+    true,
+  );
+  assert.equal(
+    tutorialShotRefsShareArtifacts({
+      sourceRoot,
+      left: upperRef,
+      right: lowerRef,
+      platform: "linux",
+    }),
+    false,
+  );
+});
+
+test("commitTutorialShotFiles restores every changed target when the second install fails", async (t) => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "shot-transaction-install-failure-"));
+  t.after(async () => {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+  const firstTarget = path.join(rootDir, "first.txt");
+  const secondTarget = path.join(rootDir, "second.txt");
+  await Promise.all([
+    fs.writeFile(firstTarget, "old first", "utf8"),
+    fs.writeFile(secondTarget, "old second", "utf8"),
+  ]);
+  let installCount = 0;
+  const events = [];
+  const fileOps = {
+    ...fs,
+    async rename(sourcePath, targetPath) {
+      if (sourcePath.endsWith(".tmp")) {
+        installCount += 1;
+        events.push(`install:${installCount}:${targetPath}`);
+        if (installCount === 2) {
+          throw new Error("injected second install failure");
+        }
+      }
+      return fs.rename(sourcePath, targetPath);
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      commitTutorialShotFiles(
+        [
+          { targetPath: firstTarget, data: "new first" },
+          { targetPath: secondTarget, data: "new second" },
+        ],
+        { fileOps },
+      ),
+    /injected second install failure/u,
+  );
+  assert.deepEqual(events, [`install:1:${firstTarget}`, `install:2:${secondTarget}`]);
+  assert.equal(await fs.readFile(firstTarget, "utf8"), "old first");
+  assert.equal(await fs.readFile(secondTarget, "utf8"), "old second");
+  assert.deepEqual(
+    (await fs.readdir(rootDir)).filter((fileName) => /\.(?:tmp|bak)$/u.test(fileName)),
+    [],
+  );
+});
+
+test("commitTutorialShotFiles retains and reports a backup when restoration fails", async (t) => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "shot-transaction-restore-failure-"));
+  t.after(async () => {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+  const firstTarget = path.join(rootDir, "first.txt");
+  const secondTarget = path.join(rootDir, "second.txt");
+  await Promise.all([
+    fs.writeFile(firstTarget, "old first", "utf8"),
+    fs.writeFile(secondTarget, "old second", "utf8"),
+  ]);
+  let installCount = 0;
+  const fileOps = {
+    ...fs,
+    async rename(sourcePath, targetPath) {
+      if (sourcePath.endsWith(".tmp")) {
+        installCount += 1;
+        if (installCount === 2) {
+          throw new Error("injected second install failure");
+        }
+      }
+      if (sourcePath.endsWith(".bak") && targetPath === firstTarget) {
+        throw new Error("injected backup restore failure");
+      }
+      return fs.rename(sourcePath, targetPath);
+    },
+  };
+
+  let transactionError;
+  try {
+    await commitTutorialShotFiles(
+      [
+        { targetPath: firstTarget, data: "new first" },
+        { targetPath: secondTarget, data: "new second" },
+      ],
+      { fileOps },
+    );
+  } catch (error) {
+    transactionError = error;
+  }
+  assert.ok(transactionError instanceof AggregateError);
+  const retainedBackups = (await fs.readdir(rootDir))
+    .filter((fileName) => fileName.endsWith(".bak"))
+    .map((fileName) => path.join(rootDir, fileName));
+  assert.equal(retainedBackups.length, 1);
+  assert.equal(await fs.readFile(retainedBackups[0], "utf8"), "old first");
+  assert.equal(
+    transactionError.errors.some((error) => error.message.includes(retainedBackups[0])),
+    true,
+  );
+  assert.equal(await fs.readFile(secondTarget, "utf8"), "old second");
+  assert.deepEqual(
+    (await fs.readdir(rootDir)).filter((fileName) => fileName.endsWith(".tmp")),
+    [],
+  );
+});
+
+test("commitTutorialShotFiles removes a newly created target without restoring a nonexistent backup", async (t) => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "shot-transaction-new-target-"));
+  t.after(async () => {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+  const newTarget = path.join(rootDir, "new.txt");
+  const existingTarget = path.join(rootDir, "existing.txt");
+  await fs.writeFile(existingTarget, "old existing", "utf8");
+  let installCount = 0;
+  const restoredTargets = [];
+  const fileOps = {
+    ...fs,
+    async rename(sourcePath, targetPath) {
+      if (sourcePath.endsWith(".tmp")) {
+        installCount += 1;
+        if (installCount === 2) {
+          throw new Error("injected second install failure");
+        }
+      }
+      if (sourcePath.endsWith(".bak")) {
+        restoredTargets.push(targetPath);
+      }
+      return fs.rename(sourcePath, targetPath);
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      commitTutorialShotFiles(
+        [
+          { targetPath: newTarget, data: "new file" },
+          { targetPath: existingTarget, data: "new existing" },
+        ],
+        { fileOps },
+      ),
+    /injected second install failure/u,
+  );
+  await assert.rejects(fs.stat(newTarget), { code: "ENOENT" });
+  assert.equal(await fs.readFile(existingTarget, "utf8"), "old existing");
+  assert.deepEqual(restoredTargets, [existingTarget]);
+  assert.deepEqual(
+    (await fs.readdir(rootDir)).filter((fileName) => /\.(?:tmp|bak)$/u.test(fileName)),
+    [],
+  );
+});
+
+test("commitTutorialShotFiles reports cleanup warnings without rolling back installed targets", async (t) => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "shot-transaction-cleanup-failure-"));
+  t.after(async () => {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+  const targetPath = path.join(rootDir, "target.txt");
+  await fs.writeFile(targetPath, "old value", "utf8");
+  const fileOps = {
+    ...fs,
+    async rm(cleanupPath, options) {
+      if (cleanupPath.endsWith(".bak")) {
+        throw new Error("injected backup cleanup failure");
+      }
+      return fs.rm(cleanupPath, options);
+    },
+  };
+
+  const result = await commitTutorialShotFiles([{ targetPath, data: "new value" }], { fileOps });
+
+  assert.equal(await fs.readFile(targetPath, "utf8"), "new value");
+  const retainedBackup = (await fs.readdir(rootDir)).find((fileName) => fileName.endsWith(".bak"));
+  assert.equal(typeof retainedBackup, "string");
+  assert.equal(result.cleanupWarnings.length, 1);
+  assert.match(result.cleanupWarnings[0], /injected backup cleanup failure/u);
+  assert.equal(result.cleanupWarnings[0].includes(path.join(rootDir, retainedBackup)), true);
+});
+
+test("saveTutorialShot succeeds with a cleanup warning after every official file is installed", async (t) => {
+  const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "shot-save-cleanup-warning-"));
+  t.after(async () => {
+    await fs.rm(sourceRoot, { recursive: true, force: true });
+  });
+  await writeTutorialFixture(sourceRoot);
+  const [shot] = await scanTutorialShots({ sourceRoot });
+  const fileOps = {
+    ...fs,
+    async rm(cleanupPath, options) {
+      if (cleanupPath.endsWith(".bak")) {
+        throw new Error("injected save cleanup failure");
+      }
+      return fs.rm(cleanupPath, options);
+    },
+  };
+
+  const result = await saveTutorialShot({
+    sourceRoot,
+    sourceRef: toTutorialShotSourceRef(shot),
+    manifestInput: { ...shot.manifest, alt: "cleanup warningでも保存成功" },
+    bootstrapFromOutput: true,
+    bootstrapImagePath: shot.bootstrapImagePath,
+    fileOps,
+  });
+
+  assert.equal(result.manifest.alt, "cleanup warningでも保存成功");
+  assert.equal(
+    result.warnings.some((warning) => warning.includes("injected save cleanup failure")),
+    true,
+  );
+  assert.match(await fs.readFile(path.join(sourceRoot, shot.pagePath), "utf8"), /startup\.webp/u);
+  await Promise.all([
+    fs.stat(path.join(sourceRoot, result.manifest.outputImagePath)),
+    fs.stat(path.join(sourceRoot, result.manifest.rawImagePath)),
+    fs.stat(path.join(sourceRoot, "content/docs/student-guide/shots/startup.shot.json")),
+  ]);
 });
 
 test("saveTutorialShot reuses a branched path and its raw image on later edits", async (t) => {


### PR DESCRIPTION
## Summary

- Identify every tutorial-shot reference with a revision-bound `referenceKey` rather than using its generated image path as UI identity.
- Allow multiple `Action` / `Verify` tags to start from the same image while remaining independently selectable and editable.
- Automatically branch only the selected reference when any generated artifact would collide.
- Preserve exact source rewriting, stale-reference rejection, and transactional save behavior across MDX, generated output, raw source, and manifest files.

## Cause

The editor previously treated `outputImagePath` as the identity of a tutorial shot. Multiple MDX tags that resolved to the same output path therefore shared React keys, selection state, crop state, and save ownership. The previous save rewrite also matched by image identity rather than the exact source reference, so one save could affect more than the selected tag.

## Reference identity

Scanning records the source page, component name, tag range, `img` value range, expected `img` value, and SHA-256 page revision. A `referenceKey` derived from that revision-bound source location uniquely identifies each reference, including repeated tags of the same kind and references on different pages.

The UI uses `referenceKey` for list keys, selection, crop ownership, keyboard activation, and editor state.

## Artifact-aware automatic branching

Before saving, the server derives the complete generated artifact set for every reference:

- generated output image
- shot manifest
- actual raw-image path

The selected reference is branched when any of those artifact identities intersects with another reference. This covers cases such as:

- `result.png` and `result.webp` converging on the same generated WebP
- different image directories producing the same manifest or raw path
- Windows case-insensitive path collisions

A collision-free six-hex `--<suffix>` path is allocated after checking existing files, all supported raw extensions, and artifacts derived from existing MDX references. Only the selected tag is rewritten. Later edits reuse the branched path instead of branching again.

## Exact source rewrite and conflict handling

Saving validates the page revision, tag location, tag name, expected `img` value, and `referenceKey`, then replaces only the selected tag's `img` attribute value slice. Other attributes, surrounding markup, and all other references remain unchanged.

A stale or mismatched source reference fails with HTTP 409 before authoritative files are changed. The UI asks the user to rescan before retrying.

## Transaction safety

The MDX update, generated output, raw source, and manifest are staged away from authoritative paths. Commit-time state is tracked per target, including temporary writes, backups, installation, and restoration.

- Operational failures roll back in reverse order.
- Newly created targets are removed without attempting a nonexistent restore.
- A backup that cannot be restored is retained and reported with its absolute path.
- Cleanup-only failures after all authoritative files are installed return a successful save with warnings rather than rolling back committed files.

## Regression coverage

- distinct shared-path references across `Action`, `Verify`, repeated same-kind tags, and multiple pages
- independent browser selection, keyboard activation, focus, responsive layout, and no duplicate React keys
- one-reference branching and exact `img` rewriting
- PNG/WebP output-policy collisions
- same-stem images in different directories
- Windows/POSIX path-case behavior
- collision-free branch allocation across all raw extensions and existing artifacts
- branched-path reuse on later edits
- stale-reference HTTP 409 with unchanged artifacts
- injected second-target installation failure with complete restoration
- retained backup when restoration fails
- rollback of newly created targets
- cleanup warning after successful authoritative installation

## Verification

- `node --test tests/tutorial-shots.test.mjs` — passed (45/45)
- `npm run lint` — passed
- `npm run test:shared` — passed
- `npm run verify:precommit` / `npm run verify` — passed
- `git diff --check` — passed
- browser walkthrough at normal width, narrow width, and with keyboard operation — passed
- GitHub Actions CI run 29885285426 — passed

## Main synchronization

The latest `main`, including PR #9's guided-task boundary contrast fix, was merged into this branch without conflicts in commit `93b30b06983c142eb5f39b090678777158169581`.
