### PR TITLE
fix: restore guided task boundary contrast

### DIFF
--- a/src/app/accessibility-overrides.css
+++ b/src/app/accessibility-overrides.css
@@ -418,7 +418,7 @@
 }
 
 .rensyuBlock .rensyuHint {
-  border-color: #b8965f !important;
+  border-color: #a16207 !important;
   background-color: #fffaf0 !important;
 }
 
@@ -427,7 +427,7 @@
 }
 
 .rensyuBlock .rensyuKaitou {
-  border-color: #72afa5 !important;
+  border-color: #0f766e !important;
   background-color: #f0fbf8 !important;
 }
 

--- a/tests/e2e/guided-tasks.spec.cjs
+++ b/tests/e2e/guided-tasks.spec.cjs
@@ -4,6 +4,180 @@ const isJavaScriptCourse = (process.env.COURSE_CONTENT_SOURCE ?? "").includes(
   "javascript-course-docs",
 );
 
+const MIN_BACKGROUND_CONTRAST = 1.1;
+const MIN_BORDER_CONTRAST = 3;
+
+const parseCssColor = (value) => {
+  const match = value.match(/rgba?\(([^)]+)\)/);
+  if (!match) {
+    throw new Error(`Unsupported computed color: ${value}`);
+  }
+
+  const channels = match[1]
+    .trim()
+    .split(/[\s,/]+/)
+    .filter(Boolean)
+    .map(Number);
+  if (channels.length < 3 || channels.some(Number.isNaN)) {
+    throw new Error(`Invalid computed color: ${value}`);
+  }
+
+  return channels.slice(0, 3);
+};
+
+const relativeLuminance = (color) => {
+  const [red, green, blue] = parseCssColor(color).map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+};
+
+const contrastRatio = (foreground, background) => {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+};
+
+test("guided task boundaries meet contrast requirements in every state", async ({ page }) => {
+  if (!isJavaScriptCourse) {
+    test.skip(true, "guided task assertions apply to the JavaScript course");
+  }
+
+  const response = await page.goto("/docs/basics/conditionals-if-elseif");
+  if (!response) throw new Error("Response is null");
+  expect(response.ok()).toBeTruthy();
+
+  const quickCheck = page.locator(".rensyuBlock.rensyuQuickCheck").first();
+  const exercise = page.locator(".rensyuBlock:not(.rensyuQuickCheck)").first();
+  const surfaces = [
+    ["QuickCheck Hint", quickCheck.locator("details.rensyuHint")],
+    ["QuickCheck Answer", quickCheck.locator("details.rensyuKaitou")],
+    ["Exercise Hint", exercise.locator("details.rensyuHint")],
+    ["Exercise Answer", exercise.locator("details.rensyuKaitou")],
+  ];
+
+  for (const [label, details] of surfaces) {
+    await expect(details, `${label}: guided task surface exists`).toHaveCount(1);
+  }
+
+  for (const theme of ["light", "dark"]) {
+    await page.evaluate((currentTheme) => {
+      document.documentElement.classList.toggle("dark", currentTheme === "dark");
+    }, theme);
+
+    for (const [state, open] of [
+      ["closed", false],
+      ["open", true],
+    ]) {
+      for (const [label, details] of surfaces) {
+        await details.evaluate((element, shouldOpen) => {
+          element.open = shouldOpen;
+        }, open);
+
+        const colors = await details.evaluate((element) => {
+          const parseColor = (value) => {
+            const match = value.match(/rgba?\(([^)]+)\)/);
+            if (!match) return null;
+            const values = match[1]
+              .trim()
+              .split(/[\s,/]+/)
+              .filter(Boolean)
+              .map(Number);
+            if (values.length < 3 || values.some(Number.isNaN)) return null;
+            return {
+              red: values[0],
+              green: values[1],
+              blue: values[2],
+              alpha: values.length > 3 ? values[3] : 1,
+            };
+          };
+
+          const blend = (foreground, background) => {
+            const alpha = foreground.alpha + background.alpha * (1 - foreground.alpha);
+            return {
+              red:
+                (foreground.red * foreground.alpha +
+                  background.red * background.alpha * (1 - foreground.alpha)) /
+                alpha,
+              green:
+                (foreground.green * foreground.alpha +
+                  background.green * background.alpha * (1 - foreground.alpha)) /
+                alpha,
+              blue:
+                (foreground.blue * foreground.alpha +
+                  background.blue * background.alpha * (1 - foreground.alpha)) /
+                alpha,
+              alpha,
+            };
+          };
+
+          const toRgb = (color) =>
+            `rgb(${Math.round(color.red)}, ${Math.round(color.green)}, ${Math.round(color.blue)})`;
+
+          const effectiveBackground = (start) => {
+            const layers = [];
+            for (let current = start; current; current = current.parentElement) {
+              const color = parseColor(getComputedStyle(current).backgroundColor);
+              if (color && color.alpha > 0) {
+                layers.push(color);
+                if (color.alpha >= 1) break;
+              }
+            }
+
+            let result = { red: 255, green: 255, blue: 255, alpha: 1 };
+            for (let index = layers.length - 1; index >= 0; index -= 1) {
+              result = blend(layers[index], result);
+            }
+            return result;
+          };
+
+          const styles = getComputedStyle(element);
+          const parentBackground = effectiveBackground(element.parentElement);
+          const elementBackground = effectiveBackground(element);
+          const border = parseColor(styles.borderTopColor);
+          if (!border) {
+            throw new Error(`Unable to parse border color: ${styles.borderTopColor}`);
+          }
+
+          return {
+            backgroundColor: styles.backgroundColor,
+            parentBackgroundColor: toRgb(parentBackground),
+            effectiveBackgroundColor: toRgb(elementBackground),
+            borderColor: styles.borderTopColor,
+            effectiveBorderColor: toRgb(blend(border, parentBackground)),
+          };
+        });
+
+        const backgroundContrast = contrastRatio(
+          colors.effectiveBackgroundColor,
+          colors.parentBackgroundColor,
+        );
+        const borderContrast = contrastRatio(
+          colors.effectiveBorderColor,
+          colors.parentBackgroundColor,
+        );
+        const diagnostic = [
+          `${label} ${theme} ${state}`,
+          `backgroundColor=${colors.backgroundColor}`,
+          `parentBackgroundColor=${colors.parentBackgroundColor}`,
+          `borderColor=${colors.borderColor}`,
+          `backgroundContrast=${backgroundContrast.toFixed(2)}`,
+          `borderContrast=${borderContrast.toFixed(2)}`,
+        ].join(" ");
+
+        expect(
+          backgroundContrast >= MIN_BACKGROUND_CONTRAST || borderContrast >= MIN_BORDER_CONTRAST,
+          diagnostic,
+        ).toBeTruthy();
+      }
+    }
+  }
+});
+
 test("conditionals page renders the Answer-only guided task flow", async ({ page }) => {
   if (!isJavaScriptCourse) {
     test.skip(true, "guided task assertions apply to the JavaScript course");


### PR DESCRIPTION
## Summary

- Strengthen the light-theme Hint and Answer borders so guided-task containers satisfy the existing boundary contrast audit.
- Keep the warm Hint and teal Answer visual semantics, all background colors, dark-theme colors, open/closed state fills, hover surfaces, and focus treatment unchanged.
- Add a focused regression test that measures the rendered boundary against the effective parent background for Exercise and QuickCheck surfaces.

## Failing GitHub Actions evidence

CI run 29830901546 reported three failed matrix jobs. Each job stopped after its first failure because `PLAYWRIGHT_MAX_FAILURES=1`.

1. `programming-course-docs`, shard 1/2, `/docs/html-basics/introduction/`, light:
   - `details.rensyuHint`: background 1.01, border 2.65
   - `details.rensyuKaitou`: background 1.01, border 2.39
2. `javascript-course-docs`, shard 1/2, `/docs/basics/array-intro/`, light:
   - `details.rensyuHint`: background 1.05, border 2.65
   - `details.rensyuKaitou`: background 1.07, border 2.39
3. `javascript-course-docs`, shard 2/2, `/docs/ui-components/slider_swiper/`, light:
   - `details.rensyuHint`: background 1.05, border 2.65
   - `details.rensyuKaitou`: background 1.07, border 2.39

The audit requires either background contrast >= 1.1 or border contrast >= 3. The thresholds and audited selectors are unchanged.

## Main reproduction

The branch started at current `origin/main` commit `d7d37c9fd9d1cad37b457ae0bcc123b28db3e740`. Before changing CSS, the CI-equivalent programming-course build and shard reproduced the same `/docs/html-basics/introduction/` failure locally with background 1.01 and borders 2.65/2.39. Recent main CI run 29488324632 also contains the same guided-task boundary failures.

## Root cause and color changes

The light-theme fills are intentionally subtle, but their contrast against the Exercise and QuickCheck parent surfaces is only 1.01–1.12. The former border colors were also too light, so neither valid boundary cue passed.

- Hint border: `#b8965f` -> `#a16207`
  - Keeps the warm amber Hint meaning and matches the existing warning palette.
- Answer border: `#72afa5` -> `#0f766e`
  - Keeps the teal Answer meaning and matches the existing success palette.

These darker semantic borders provide substantial margin over the 3.0 requirement without making the panel fills visually heavy. Backgrounds and all dark-theme colors remain unchanged.

## Rendered contrast after the fix

Border contrast is the stable passing cue for both closed and open states:

| Theme | Task | Hint border | Answer border |
| --- | --- | ---: | ---: |
| Light | QuickCheck | 4.92 | 5.47 |
| Light | Exercise | 4.71 | 5.23 |
| Dark | QuickCheck | 7.27 | 6.01 |
| Dark | Exercise | 6.86 | 5.67 |

Open fills remain visibly different from closed fills. Their measured background contrast ranges are:

- Light QuickCheck: 1.04/1.09 Hint, 1.06/1.12 Answer (closed/open)
- Light Exercise: 1.01/1.05 Hint, 1.01/1.07 Answer
- Dark QuickCheck: 1.16/1.29 Hint, 1.17/1.39 Answer
- Dark Exercise: 1.09/1.21 Hint, 1.10/1.31 Answer

The rendered Hint/Answer colors, open/closed fills, Exercise/QuickCheck framing, summary text, icons, chevrons, full-width hover surfaces, yellow focus-visible outline, and 375 px no-overflow behavior remain distinct.

## Regression coverage

`tests/e2e/guided-tasks.spec.cjs` now measures all 16 combinations:

- Exercise and QuickCheck
- Hint and Answer
- light and dark
- closed and open

For every surface, it resolves the effective parent background, composites the rendered background and border colors, calculates WCAG contrast, and requires background >= 1.1 or border >= 3. Failure diagnostics include label, theme, state, computed colors, and both ratios. The existing guided-task test continues to cover visual distinction, full-width hover, keyboard activation, focus outline containment, and 375 px overflow.

## Verification

- New regression before the CSS fix: failed as expected at QuickCheck Hint light/closed (background 1.04, border 2.78)
- `tests/e2e/guided-tasks.spec.cjs`: 2 passed
- JavaScript `tests/e2e/contrast.spec.cjs`: 50 passed
- Programming `tests/e2e/contrast.spec.cjs`: 6 passed, 1 skipped
- Programming full course E2E shard 1/2: 7 passed, 1 skipped
- JavaScript full course E2E shard 1/2: 27 passed, 2 skipped
- JavaScript full course E2E shard 2/2: 28 passed, 1 skipped
- `npm run lint`: passed
- `npm run test:shared`: passed
- `npm run verify:precommit`: passed
- `git diff --check`: passed
- Commit hook `verify:precommit`: passed
- Production-build browser walkthrough: light/dark, closed/open, focus-visible, and 375 px screenshots reviewed; screenshots remain in the OS temp directory and are not committed

## Relationship to PR #8

This is independent of tutorial-shots PR #8. It was created from current `origin/main` on a separate branch and does not modify, merge, rebase, or mark PR #8 ready. The intended order is to merge this PR into main first, then bring the updated main into PR #8 separately.
